### PR TITLE
add support for extended JSON for index direction, additional dry-run output

### DIFF
--- a/index-tool/migrationtools/documentdb_index_tool.py
+++ b/index-tool/migrationtools/documentdb_index_tool.py
@@ -459,6 +459,8 @@ class DocumentDbIndexTool(IndexToolConstants):
 
                         if type(index_direction) is float:
                             index_direction = int(index_direction)
+                        elif type(index_direction) is dict and '$numberInt' in index_direction:
+                            index_direction = int(index_direction['$numberInt'])
 
                         keys_to_create.append((key, index_direction))
 
@@ -473,8 +475,8 @@ class DocumentDbIndexTool(IndexToolConstants):
                         logging.info(
                             "(dry run) %s.%s: would attempt to add index: %s",
                             db_name, collection_name, index_name)
-                        logging.info("(dry run) %s.%s.%s index options: %s",
-                            db_name, collection_name, index_name, index_options)
+                        logging.info("  (dry run) index options: %s", index_options)
+                        logging.info("  (dry run) index keys: %s", keys_to_create)
                     else:
                         logging.debug("Adding index %s -> %s", keys_to_create,
                                       index_options)


### PR DESCRIPTION
Added code to handle case where extended JSON is used for index direction. Cleaned up one existing line of dry-run output and added an additional line of dry-run outpt.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
