### PR TITLE
add --dump-indexes option to dumping indexes command

### DIFF
--- a/index-tool/README.md
+++ b/index-tool/README.md
@@ -16,7 +16,7 @@ Clone the repository, then run the following command in the repo top-level direc
 
 ## Using the Index Tool
 To dump indexes from a running MongoDB instance or replica set, run the following command:
-`python migrationtools/documentdb_index_tool.py --host <host> --port <port> --username <username> --password <password> --auth-db <auth db> --dir <directory to dump metadata to>`
+`python migrationtools/documentdb_index_tool.py --dump-indexes --host <host> --port <port> --username <username> --password <password> --auth-db <auth db> --dir <directory to dump metadata to>`
 
 To check for compatibility issues against dumped database metadata, run the following command:
 `python migrationtools/documentdb_index_tool.py --show-issues  --dir <directory that contains metadata dump>`


### PR DESCRIPTION
*Issue #, if available:*
The command for dumping indexes at Readme file was missing --dump-indexes option

*Description of changes:*
Added the option to the readme

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
