### PR TITLE
add support for MongoDB 4.4+

### DIFF
--- a/index-tool/migrationtools/documentdb_index_tool.py
+++ b/index-tool/migrationtools/documentdb_index_tool.py
@@ -256,9 +256,13 @@ class DocumentDbIndexTool(IndexToolConstants):
                     collection_metadata = {}
                     collection_indexes = connection[database_name][
                         collection_name].list_indexes()
-                    collection_metadata[self.INDEXES] = [
-                        index for index in collection_indexes
-                    ]
+                    thisIndexes = []
+                    for thisIndex in collection_indexes:
+                        if "ns" not in thisIndex:
+                            # mdb44+ eliminated the "ns" attribute
+                            thisIndex["ns"] = "{}.{}".format(database_name,collection_name)
+                        thisIndexes.append(thisIndex)
+                    collection_metadata[self.INDEXES] = thisIndexes
                     collection_metadata[self.OPTIONS] = connection[
                         database_name][collection_name].options()
 


### PR DESCRIPTION
MongoDB 4.4 removed the "ns" attribute from the getIndexes() command. Adding it back to the JSON when dumping indexes if not present.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
