### PR TITLE
pymongo v4 not compatible (Unknown option ssl_ca_certs)

### DIFF
--- a/index-tool/requirements.txt
+++ b/index-tool/requirements.txt
@@ -1,1 +1,1 @@
-pymongo >= 2.9
+pymongo >= 2.9, < 4.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`ssl_ca_certs` is not an option with v4+ of the pymongo library. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
