### PR TITLE
views do not have indexes, skip them

### DIFF
--- a/index-tool/migrationtools/documentdb_index_tool.py
+++ b/index-tool/migrationtools/documentdb_index_tool.py
@@ -265,6 +265,11 @@ class DocumentDbIndexTool(IndexToolConstants):
                         database_name].list_collection_names():
                     logging.debug("Collection: %s", collection_name)
                     collection_metadata = {}
+                    collection_metadata[self.OPTIONS] = connection[
+                        database_name][collection_name].options()
+                    if 'viewOn' in collection_metadata[self.OPTIONS]:
+                        # views cannot have indexes, skip to next collection
+                        continue
                     collection_indexes = connection[database_name][
                         collection_name].list_indexes()
                     thisIndexes = []
@@ -274,8 +279,6 @@ class DocumentDbIndexTool(IndexToolConstants):
                             thisIndex["ns"] = "{}.{}".format(database_name,collection_name)
                         thisIndexes.append(thisIndex)
                     collection_metadata[self.INDEXES] = thisIndexes
-                    collection_metadata[self.OPTIONS] = connection[
-                        database_name][collection_name].options()
 
                     collection_metadata_filename = "{}.{}".format(
                         collection_name, self.METADATA_FILE_SUFFIX_PATTERN)


### PR DESCRIPTION
*Issue #, if available:*
#33 

*Description of changes:*
Test if the given collection is a view earlier, skip as views cannot have indexes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
