### PR TITLE
docs: NOTICKET - Fix typo in docs for enabling query logging for compat-tool

### DIFF
--- a/compat-tool/README.md
+++ b/compat-tool/README.md
@@ -32,7 +32,7 @@ To enable logging of queries to the MongoDB logs you enable the query profiler
 and set the `slowms` to `-1`, which will cause all queries to be logged.
 To do so, run the following query from the `mongo` shell.
 ```
-db.setProfilingLevel(0, -1)
+db.setProfilingLevel(2, -1)
 ```
 
 It is recommended to use a dev/test MongoDB installation to capture the queries, as


### PR DESCRIPTION
## *Description of changes:*
* Please let me know if I've just misunderstood how this works or done it wrong, but after following the docs for `Enabling query logging` I'm not see'ing any queries logged if I run `db.system.profile.find().pretty()`

* According to the [MongoDB Documentation](https://www.mongodb.com/docs/v3.6/reference/method/db.setProfilingLevel/) the first parameter to `db.setProfilingLevel` is `level`.
* The docs previously suggested setting this to `0`, which means

> The profiler is off and does not collect any data. This is the default profiler level.

* This means you'll never get any logs, even with `slowms` set to `-1` (the second parameter to `db.setProfilingLevel`)
* I've suggested setting it to `2` which means

> The profiler collects data for all operations.

* But I guess setting it to `1` would also work:

> The profiler collects data for operations that take longer than the value of slowms.


* By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
