### PR TITLE
feat: Add ability to only sample a certain percentage of documents when comparing data between MongoDB and DocDB

### DIFF
--- a/migration/data-differ/README.md
+++ b/migration/data-differ/README.md
@@ -28,8 +28,7 @@ cd amazon-documentdb-tools/migration/data-differ/
 
 ```
 python3 data-differ.py --help
-usage: data-differ.py [-h] [--batch_size BATCH_SIZE] [--output_file OUTPUT_FILE] [--check_target CHECK_TARGET] --source-uri SOURCE_URI --target-uri TARGET_URI --source-db SOURCE_DB --target-db TARGET_DB --source-coll
-                      SOURCE_COLL --target-coll TARGET_COLL
+usage: data-differ.py [-h] [--batch_size BATCH_SIZE] [--output_file OUTPUT_FILE] [--check_target CHECK_TARGET] --source-uri SOURCE_URI --target-uri TARGET_URI --source-db SOURCE_DB --target-db TARGET_DB --source-coll SOURCE_COLL --target-coll TARGET_COLL [--sample_size_percent SAMPLE_SIZE_PERCENT]
 
 Compare two collections and report differences.
 
@@ -53,6 +52,8 @@ options:
                         Source collection name (required)
   --target-coll TARGET_COLL
                         Target collection name (required)
+  --sample_size_percent SAMPLE_SIZE_PERCENT
+                        optional, if set only samples a percentage of the documents
 ```
 
 ## Example usage:
@@ -71,3 +72,18 @@ python3 data-differ-args.py \
 ```
 
 For more information on the connection string format, refer to the [documentation](https://www.mongodb.com/docs/manual/reference/connection-string/).
+
+## Sampling
+For large databases it might be unfeasible to compare every document as:
+* It takes a long time to compare every document.
+* Reading every document from a large busy database could have a performance impact.
+
+If you use the `--sample_size_percent` option you can pass in a percentage of
+documents to sample and compare.
+
+E.g. `--sample_size_percent 1` would sample 1% of the documents in the source
+database and compare them to the target database.
+
+Under the hood this uses the [MongoDB `$sample` operator](https://www.mongodb.com/docs/manual/reference/operator/aggregation/sample/)
+You should read the documentation on how that behaves on your version of MongoDB
+when the percentage to sample is >= 5% before picking a percentage to sample.

--- a/migration/data-differ/README.md
+++ b/migration/data-differ/README.md
@@ -28,7 +28,7 @@ cd amazon-documentdb-tools/migration/data-differ/
 
 ```
 python3 data-differ.py --help
-usage: data-differ.py [-h] [--batch_size BATCH_SIZE] [--output_file OUTPUT_FILE] [--check_target CHECK_TARGET] --source-uri SOURCE_URI --target-uri TARGET_URI --source-db SOURCE_DB --target-db TARGET_DB --source-coll SOURCE_COLL --target-coll TARGET_COLL [--sample_size_percent SAMPLE_SIZE_PERCENT]
+usage: data-differ.py [-h] [--batch_size BATCH_SIZE] [--output_file OUTPUT_FILE] [--check_target CHECK_TARGET] --source-uri SOURCE_URI --target-uri TARGET_URI --source-db SOURCE_DB --target-db TARGET_DB --source-coll SOURCE_COLL --target-coll TARGET_COLL [--sample_size_percent SAMPLE_SIZE_PERCENT] [--sampling_timeout_ms SAMPLING_TIMEOUT_MS]
 
 Compare two collections and report differences.
 
@@ -54,6 +54,8 @@ options:
                         Target collection name (required)
   --sample_size_percent SAMPLE_SIZE_PERCENT
                         optional, if set only samples a percentage of the documents
+  --sampling_timeout_ms SAMPLING_TIMEOUT_MS
+                        optional, override the timeout for returning a sample of documents when using the --sample_size_percent argument
 ```
 
 ## Example usage:
@@ -87,3 +89,7 @@ database and compare them to the target database.
 Under the hood this uses the [MongoDB `$sample` operator](https://www.mongodb.com/docs/manual/reference/operator/aggregation/sample/)
 You should read the documentation on how that behaves on your version of MongoDB
 when the percentage to sample is >= 5% before picking a percentage to sample.
+
+The default timeout for retriving a sample of documents is `500ms`, if this is
+not long enough you can adjust it with the `--sampling_timeout_ms` argument.
+For example `--sample_timeout_ms 600` would increase the timeout to `600ms`.

--- a/migration/data-differ/data-differ.py
+++ b/migration/data-differ/data-differ.py
@@ -39,11 +39,11 @@ def compare_docs_deepdiff(doc1, doc2, output_file):
 
 
 ## Main compare document function
-def compare_document_data(srcCollection, tgtCollection, batch_size, output_file, src_count, sample_size_percent):
+def compare_document_data(srcCollection, tgtCollection, batch_size, output_file, src_count, sample_size_percent, sampling_timeout_ms):
     if sample_size_percent:
         percentage_in_decimal = sample_size_percent / 100
         docs_to_sample = int(percentage_in_decimal * src_count)
-        source_cursor = srcCollection.aggregate([ { "$sample": { "size": docs_to_sample } } ], batchSize=batch_size, maxTimeMS=500)
+        source_cursor = srcCollection.aggregate([ { "$sample": { "size": docs_to_sample } } ], batchSize=batch_size, maxTimeMS=sampling_timeout_ms)
         total_docs = docs_to_sample
     else:
         source_cursor = srcCollection.find().sort('_id').batch_size(batch_size)
@@ -114,7 +114,7 @@ def write_difference_to_file(output_file, content):
         file.write(str(content) + '\n')
 
 
-def compare_collections(srcCollection, tgtCollection, batch_size, output_file, check_target, sample_size_percent):
+def compare_collections(srcCollection, tgtCollection, batch_size, output_file, check_target, sample_size_percent, sampling_timeout_ms):
     src_count = srcCollection.count_documents({})
     trg_count = tgtCollection.count_documents({})
 
@@ -130,7 +130,7 @@ def compare_collections(srcCollection, tgtCollection, batch_size, output_file, c
     write_difference_to_file(output_file, "Count of documents in target:" + str(trg_count) )
 
     print(f"Starting data differ at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')} , output is saved to {output_file}")
-    compare_document_data(srcCollection, tgtCollection, batch_size, output_file, src_count, sample_size_percent)
+    compare_document_data(srcCollection, tgtCollection, batch_size, output_file, src_count, sample_size_percent, sampling_timeout_ms)
     compare_indexes(srcCollection, tgtCollection, output_file)
     if check_target :
         check_target_for_extra_documents(srcCollection, tgtCollection, output_file)
@@ -148,6 +148,7 @@ def main():
     parser.add_argument('--source-coll', type=str, required=True, help='Source collection name (required)')
     parser.add_argument('--target-coll', type=str, required=True, help='Target collection name (required)')
     parser.add_argument('--sample_size_percent', type=int, required=False, help='optional, if set only samples a percentage of the documents')
+    parser.add_argument('--sampling_timeout_ms', type=int, default=500, required=False, help='optional, override the timeout for returning a sample of documents when using the --sample_size_percent argument')
     args = parser.parse_args()
 
     # Connect to the source database cluster
@@ -161,7 +162,7 @@ def main():
     tgtCollection = tgtdb[args.target_coll]
 
     # Compare collections and report differences
-    compare_collections(srcCollection, tgtCollection, args.batch_size, args.output_file, args.check_target, args.sample_size_percent)
+    compare_collections(srcCollection, tgtCollection, args.batch_size, args.output_file, args.check_target, args.sample_size_percent, args.sampling_timeout_ms)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Overview
* We're using this tool to compare the contents of MongoDB and DocDB after transferring the data via DMS
* For our larger databases this takes a long time to run and we're not sure about the performance implications of reading every document from a large database
* We spoke with our AWS Account Rep and they suggested that we'd want to use the tool to more spot check documents rather than check all of them  
* So I've implemented the ability to sample a certain percentage of the documents

## Testing on "real" Databases
* We've ran this against one of our databases being migrated and it runs successfully

### No Sampling (100%)
* Note the total is 124319

```
python3 data-differ.py <assorted redacted options>

Starting data differ at 2023-10-18 13:27:39 , output is saved to differences.txt

Comparing documents: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▉| 124300/124319 [03:17<00:00, 850.23doc/s]
```

### 1% Sampling
* Note that the total is 1243, or 1% of 124319 from above

```
python3 data-differ.py <assorted redacted options> --sample_size_percent 1 --output_file aaron

Starting data differ at 2023-10-18 13:50:45 , output is saved to aaron
Comparing documents: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1243/1243 [00:02<00:00, 619.17doc/s]
```

### Testing on Docker Databases
* I spun up a source and target Mongo database in a Docker container and enabled query logging so we can verify what happens
* I inserted 200 documents 
* I ran the data diff tool sampling 1% of documents

```
python3 data-differ.py --source-uri 'mongodb://root:rootpassword@localhost:27017' --target-uri 'mongodb://root:rootpassword@localhost:27018' --source-db vandelay --target-db vandelay --source-coll people --target-col people --sample_size_percent 1 --batch_size 1
```

* We see the `$sample` query for 2 documents

```
data-differ-mongodb_source-1          | 2023-10-18T14:03:51.246+0000 I COMMAND  [conn28] command vandelay.people command: aggregate { aggregate: "people", pipeline: [ { $sample: { size: 2 } } ], maxTimeMS: 500, cursor: { batchSize: 1 }, lsid: { id: UUID("3a85552a-1233-44e9-b416-5b7d6ac9c724") }, $db: "vandelay" } planSummary: MULTI_ITERATOR cursorid:4991115756395818380 keysExamined:0 docsExamined:0 numYields:151 nreturned:1 reslen:140 locks:{ Global: { acquireCount: { r: 306 } }, Database: { acquireCount: { r: 153 } }, Collection: { acquireCount: { r: 153 } } } protocol:op_msg 15ms
```

* We see those 2 docs iterated over 

```
data-differ-mongodb_target-1          | 2023-10-18T14:03:51.258+0000 I COMMAND  [conn28] command vandelay.people command: find { find: "people", filter: { _id: { $in: [ ObjectId('652fe4ec82ccc7e158c20bea') ] } }, lsid: { id: UUID("b476046c-9199-480c-bc81-b000349fa230") }, $db: "vandelay" } planSummary: IXSCAN { _id: 1 } keysExamined:0 docsExamined:0 cursorExhausted:1 numYields:0 nreturned:0 reslen:88 locks:{ Global: { acquireCount: { r: 2 } }, Database: { acquireCount: { r: 1 } }, Collection: { acquireCount: { r: 1 } } } protocol:op_msg 0ms

data-differ-mongodb_source-1          | 2023-10-18T14:03:51.311+0000 I COMMAND  [conn28] command vandelay.people command: getMore { getMore: 4991115756395818380, collection: "people", batchSize: 2, lsid: { id: UUID("3a85552a-1233-44e9-b416-5b7d6ac9c724") }, $db: "vandelay" } originatingCommand: { aggregate: "people", pipeline: [ { $sample: { size: 2 } } ], maxTimeMS: 500, cursor: { batchSize: 1 }, lsid: { id: UUID("3a85552a-1233-44e9-b416-5b7d6ac9c724") }, $db: "vandelay" } planSummary: MULTI_ITERATOR cursorid:4991115756395818380 keysExamined:0 docsExamined:0 cursorExhausted:1 numYields:0 nreturned:1 reslen:138 locks:{ Global: { acquireCount: { r: 4 } }, Database: { acquireCount: { r: 2 } }, Collection: { acquireCount: { r: 1 } } } protocol:op_msg 1ms

data-differ-mongodb_target-1          | 2023-10-18T14:03:51.312+0000 I COMMAND  [conn28] command vandelay.people command: find { find: "people", filter: { _id: { $in: [ ObjectId('652fe4ec82ccc7e158c20b4c') ] } }, lsid: { id: UUID("b476046c-9199-480c-bc81-b000349fa230") }, $db: "vandelay" } planSummary: IXSCAN { _id: 1 } keysExamined:0 docsExamined:0 cursorExhausted:1 numYields:0 nreturned:0 reslen:88 locks:{ Global: { acquireCount: { r: 2 } }, Database: { acquireCount: { r: 1 } }, Collection: { acquireCount: { r: 1 } } } protocol:op_msg 0ms
``` 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
