### PR TITLE
Update documentdb_index_tool.py to add optional index name shorten option

### DIFF
--- a/index-tool/migrationtools/documentdb_index_tool.py
+++ b/index-tool/migrationtools/documentdb_index_tool.py
@@ -469,7 +469,7 @@ class DocumentDbIndexTool(IndexToolConstants):
                     if (len(collection_qualified_index_name) > DocumentDbLimits.COLLECTION_QUALIFIED_INDEX_NAME_MAX_LENGTH  or 
                         len(fully_qualified_index_name) > DocumentDbLimits.FULLY_QUALIFIED_INDEX_NAME_MAX_LENGTH):
                         short_index_name = index_name[:(DocumentDbLimits.COLLECTION_QUALIFIED_INDEX_NAME_MAX_LENGTH - 
-                            (len(collection_qualified_index_name)+5))] +''.join(random.choices(alphabet, k=5))
+                            (len(collection_name)+6))] +''.join(random.choices(alphabet, k=5))
                         index_options[self.INDEX_NAME] = short_index_name
                     else:   
                         index_options[self.INDEX_NAME] = index_name


### PR DESCRIPTION
Implemented an optional feature to shorten index names to 7 characters consisting of "i_" plus a 5 character random string. This addresses the index name (\<db\>.\<col\>.$\<index\>) length requirement of 6-127 characters. Since fully qualified collection name can be up to 120 characters in the format \<db\>.\<col\>, index names need to be limited to 7 characters to meet the combined name length restriction.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
