### PR TITLE
Fixed the issue of ever expanding global cluster name

### DIFF
--- a/global-clusters-automation/failover_and_convert_to_global.py
+++ b/global-clusters-automation/failover_and_convert_to_global.py
@@ -89,6 +89,12 @@ def get_cluster_details(cluster):
         vpc_group_ids = []
         for each_item in cluster_response['VpcSecurityGroups']:
             vpc_group_ids.append(each_item['VpcSecurityGroupId'])
+        
+        if "-flipped" in cluster_id:
+            last_index = cluster_id.rfind("-")
+            cluster_id = cluster_id[:last_index]
+        else:
+            cluster_id = cluster_id + "-flipped"
 
         cluster_details = {
             # When converting the cluster to global cluster and adding clusters from the prior global


### PR DESCRIPTION
*Issue #, if available:* 128

*Description of changes:* Fixed the issue of ever expanding global cluster name when doing multiple failovers. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
