### PR TITLE
Fix typo in data-differ README.md example usage section

### DIFF
--- a/migration/data-differ/README.md
+++ b/migration/data-differ/README.md
@@ -64,7 +64,7 @@ Connect to a standalone MongoDB instance as source and to a Amazon DocumentDB cl
 From the source uri, compare the collection *mysourcecollection* from database *mysource*, against the collection *mytargetcollection* from database *mytargetdb* in the target uri.
 
 ```
-python3 data-differ-args.py \
+python3 data-differ.py \
 --source-uri "mongodb://user:password@mongodb-instance-hostname:27017/admin?directConnection=true" \
 --target-uri "mongodb://user:password@target.cluster.docdb.amazonaws.com:27017/?tls=true&tlsCAFile=rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false" \
 --source-db mysourcedb \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix typo in data-differ README.md.

https://github.com/awslabs/amazon-documentdb-tools/blob/1e88b7ca50084c25b6fad849b69b6528610e9ea4/migration/data-differ/README.md#L67

There is no `data-differ-args.py` file in data-differ directory and it was intended to direct `data-differ.py`.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
