### PR TITLE
Fix some camel cased args into kebab case

### DIFF
--- a/migration/data-differ/README.md
+++ b/migration/data-differ/README.md
@@ -28,17 +28,17 @@ cd amazon-documentdb-tools/migration/data-differ/
 
 ```
 python3 data-differ.py --help
-usage: data-differ.py [-h] [--batch_size BATCH_SIZE] [--output_file OUTPUT_FILE] [--check_target CHECK_TARGET] --source-uri SOURCE_URI --target-uri TARGET_URI --source-db SOURCE_DB --target-db TARGET_DB --source-coll SOURCE_COLL --target-coll TARGET_COLL [--sample_size_percent SAMPLE_SIZE_PERCENT] [--sampling_timeout_ms SAMPLING_TIMEOUT_MS]
+usage: data-differ.py [-h] [--batch-size BATCH_SIZE] [--output_-ile OUTPUT_FILE] [--check-target CHECK_TARGET] --source-uri SOURCE_URI --target-uri TARGET_URI --source-db SOURCE_DB --target-db TARGET_DB --source-coll SOURCE_COLL --target-coll TARGET_COLL [--sample-size_percent SAMPLE_SIZE_PERCENT] [--sampling-timeout-ms SAMPLING_TIMEOUT_MS]
 
 Compare two collections and report differences.
 
 options:
   -h, --help            show this help message and exit
-  --batch_size BATCH_SIZE
+  --batch-size BATCH_SIZE
                         Batch size for bulk reads (optional, default: 100)
-  --output_file OUTPUT_FILE
+  --output-file OUTPUT_FILE
                         Output file path (optional, default: differences.txt)
-  --check_target CHECK_TARGET
+  --check-target CHECK_TARGET
                         optional, Check if extra documents exist in target database
   --source-uri SOURCE_URI
                         Source cluster URI (required)
@@ -52,10 +52,10 @@ options:
                         Source collection name (required)
   --target-coll TARGET_COLL
                         Target collection name (required)
-  --sample_size_percent SAMPLE_SIZE_PERCENT
+  --sample-size-percent 
                         optional, if set only samples a percentage of the documents
-  --sampling_timeout_ms SAMPLING_TIMEOUT_MS
-                        optional, override the timeout for returning a sample of documents when using the --sample_size_percent argument
+  --sampling-timeout-ms 
+                        optional, override the timeout for returning a sample of documents when using the --sample-size-percent argument
 ```
 
 ## Example usage:
@@ -80,10 +80,10 @@ For large databases it might be unfeasible to compare every document as:
 * It takes a long time to compare every document.
 * Reading every document from a large busy database could have a performance impact.
 
-If you use the `--sample_size_percent` option you can pass in a percentage of
+If you use the `--sample-size-percent` option you can pass in a percentage of
 documents to sample and compare.
 
-E.g. `--sample_size_percent 1` would sample 1% of the documents in the source
+E.g. `--sample-size-percent 1` would sample 1% of the documents in the source
 database and compare them to the target database.
 
 Under the hood this uses the [MongoDB `$sample` operator](https://www.mongodb.com/docs/manual/reference/operator/aggregation/sample/)
@@ -91,5 +91,5 @@ You should read the documentation on how that behaves on your version of MongoDB
 when the percentage to sample is >= 5% before picking a percentage to sample.
 
 The default timeout for retriving a sample of documents is `500ms`, if this is
-not long enough you can adjust it with the `--sampling_timeout_ms` argument.
-For example `--sample_timeout_ms 600` would increase the timeout to `600ms`.
+not long enough you can adjust it with the `--sampling-timeout-ms` argument.
+For example `--sample-timeout-ms 600` would increase the timeout to `600ms`.

--- a/migration/data-differ/README.md
+++ b/migration/data-differ/README.md
@@ -52,9 +52,9 @@ options:
                         Source collection name (required)
   --target-coll TARGET_COLL
                         Target collection name (required)
-  --sample-size-percent 
+  --sample-size-percent SAMPLE_SIZE_PERCENT
                         optional, if set only samples a percentage of the documents
-  --sampling-timeout-ms 
+  --sampling-timeout-ms SAMPLING_TIMEOUT_MS
                         optional, override the timeout for returning a sample of documents when using the --sample-size-percent argument
 ```
 

--- a/migration/data-differ/data-differ.py
+++ b/migration/data-differ/data-differ.py
@@ -138,17 +138,17 @@ def compare_collections(srcCollection, tgtCollection, batch_size, output_file, c
 
 def main():
     parser = argparse.ArgumentParser(description='Compare two collections and report differences.')
-    parser.add_argument('--batch_size', type=int, default=100, help='Batch size for bulk reads (optional, default: 100)')
-    parser.add_argument('--output_file', type=str, default='differences.txt', help='Output file path (optional, default: differences.txt)')
-    parser.add_argument('--check_target', type=str, default=False, help='optional, Check if extra documents exist in target database')
+    parser.add_argument('--batch-size', type=int, default=100, help='Batch size for bulk reads (optional, default: 100)')
+    parser.add_argument('--output-file', type=str, default='differences.txt', help='Output file path (optional, default: differences.txt)')
+    parser.add_argument('--check-target', type=str, default=False, help='optional, Check if extra documents exist in target database')
     parser.add_argument('--source-uri', type=str, required=True, help='Source cluster URI (required)')
     parser.add_argument('--target-uri', type=str, required=True, help='Target cluster URI (required)')
     parser.add_argument('--source-db', type=str, required=True, help='Source database name (required)')
     parser.add_argument('--target-db', type=str, required=True, help='Target database name (required)')
     parser.add_argument('--source-coll', type=str, required=True, help='Source collection name (required)')
     parser.add_argument('--target-coll', type=str, required=True, help='Target collection name (required)')
-    parser.add_argument('--sample_size_percent', type=int, required=False, help='optional, if set only samples a percentage of the documents')
-    parser.add_argument('--sampling_timeout_ms', type=int, default=500, required=False, help='optional, override the timeout for returning a sample of documents when using the --sample_size_percent argument')
+    parser.add_argument('--sample-size-percent', type=int, required=False, help='optional, if set only samples a percentage of the documents')
+    parser.add_argument('--sampling-timeout-ms', type=int, default=500, required=False, help='optional, override the timeout for returning a sample of documents when using the --sample-size-percent argument')
     args = parser.parse_args()
 
     # Connect to the source database cluster


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The data-differ.py arguments have camel cased arguments and kebab cased arguments concurrently which could be confused.

Change all camel cased arguments into kebab cased. 

I think it would be intended because all camel cased arguments are optional arguments.

If you think this change isn't acceptable you could close this PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
