### PR TITLE
fix: "missing operator" message

### DIFF
--- a/compat-tool/compat.py
+++ b/compat-tool/compat.py
@@ -263,7 +263,7 @@ def main(args):
             print("The following {} unsupported operators were found:".format(notCompatCounter))
             for thisKey in sorted(usageDict.keys()):
                 if (thisKey not in keywords):
-                    print("  {} | executed {} time(s) - WARNING - operator is missing from compa tool, please file an issue".format(thisKeyPair[0],thisKeyPair[1]))
+                    print("  {} | executed {} time(s) - WARNING - operator is missing from compa tool, please file an issue".format(thisKey,usageDict[thisKey]))
                 elif (usageDict[thisKey] > 0) and (keywords[thisKey][ver] == 'No'):
                     print("  {} | executed {} time(s)".format(thisKey,usageDict[thisKey]))
         else:


### PR DESCRIPTION

before fix:
```
The following 1 unsupported operators were found:
Traceback (most recent call last):
  File "/Users/marxus/Projects/salt/amazon-documentdb-tools/compat-tool/compat.py", line 612, in <module>
    main(sys.argv[1:])
  File "/Users/marxus/Projects/salt/amazon-documentdb-tools/compat-tool/compat.py", line 266, in main
    print("  {} | executed {} time(s) - WARNING - operator is missing from compa tool, please file an issue".format(thisKeyPair[0],thisKeyPair[1]))
                                                                                                                    ^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'thisKeyPair' where it is not associated with a value
```


after fix:
```
The following 1 unsupported operators were found:
  $backupCursor | executed 0 time(s) - WARNING - operator is missing from compa tool, please file an issue
  $backupCursorExtend | executed 0 time(s) - WARNING - operator is missing from compa tool, please file an issue
  $queryStats | executed 2 time(s)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
