### PR TITLE
Skip restore-time index failures with --skip-incompatible

### DIFF
--- a/index-tool/migrationtools/documentdb_index_tool.py
+++ b/index-tool/migrationtools/documentdb_index_tool.py
@@ -534,8 +534,21 @@ class DocumentDbIndexTool(IndexToolConstants):
                             logging.debug("Adding index %s -> %s", keys_to_create,index_options)
                             database = connection[db_name]
                             collection = database[collection_name]
-                            collection.create_index(keys_to_create,**index_options)
-                            logging.info("%s.%s: added index: %s", db_name, collection_name, index_options[self.INDEX_NAME] )
+                            try:
+                                collection.create_index(keys_to_create,**index_options)
+                                logging.info("%s.%s: added index: %s", db_name, collection_name, index_options[self.INDEX_NAME] )
+                            except OperationFailure as ofe:
+                                if self.args.skip_incompatible is True:
+                                    logging.warning(
+                                        "%s.%s: skipping index %s because create_index failed: %s",
+                                        db_name,
+                                        collection_name,
+                                        index_options[self.INDEX_NAME],
+                                        ofe,
+                                    )
+                                    continue
+
+                                raise
 
     def run(self):
         """Entry point


### PR DESCRIPTION
## Summary
- Catch `OperationFailure` raised by `create_index` during index restore when `--skip-incompatible` is enabled.
- Log the failed index and continue restoring remaining indexes.
- Preserve existing behavior when `--skip-incompatible` is not enabled.

## Why
While testing the index tool, agent found that `--skip-incompatible` only skipped incompatibilities detected from metadata before restore. Some DocumentDB incompatibilities are only reported at create time. For example, a compound text index with 3 or more weighted text fields can pass the metadata compatibility checks, but DocumentDB rejects it during `create_index`. In those cases, the restore aborted with an unhandled `OperationFailure` instead of skipping the incompatible index.

## Validation
- Verified the updated index tool module compiles successfully with `py_compile`.
