### PR TITLE
mvu-tool: Harden CDC migrator for compound unique indexes, add dedicated threading, and fix batch handling

### DIFF
--- a/migration/mvu-tool/README.md
+++ b/migration/mvu-tool/README.md
@@ -1,72 +1,208 @@
 # Amazon DocumentDB MVU CDC Migrator Tool
 
-The purpose of mvu cdc migrator tool is to migrate the cluster wide changes from source Amazon DocumentDB Cluster to target  Amazon DocumentDB Cluster.
+The purpose of MVU CDC migrator tool is to migrate the cluster wide changes from source Amazon DocumentDB cluster to target Amazon DocumentDB cluster.
 
-It enables to perform near zero downtime Major Version Upgrade(MVU) from Amazon DocumentDB 3.6  to Amazon DocumentDB 5.0.
+It enables a near-zero downtime [major version upgrade (MVU)](https://docs.aws.amazon.com/documentdb/latest/devguide/docdb-mvu.html) from Amazon DocumentDB 3.6 to Amazon DocumentDB 5.0.
 
 This tool is only recommended for performing MVU from Amazon DocumentDB 3.6. If you are performing MVU from Amazon DocumentDB 4.0 to 5.0, we recommend using the AWS Database Migration Service CDC approach.
 
-## Prerequisites:
+---
 
- - Python 3
- - Modules: pymongo
+## Prerequisites
+
+- Python 3.7+
+- pymongo 3.7+
+
+```terminal
+  pip3 install "pymongo>=3.7"
 ```
-  pip3 install pymongo
-```
+
+---
+
 ## How to use
 
 1. Clone the repository and go to the tool folder:
-```
+
+```terminal
 git clone https://github.com/awslabs/amazon-documentdb-tools.git
 cd amazon-documentdb-tools/mvu-tool/
 ```
 
-2. Run the mvu-cdc-migrator.py tool to capature the cluster wide change stream token and migrate the changes. It accepts the following arguments:
-```
-python3 mvu-cdc-migrator.py  --help
-usage: mvu-cdc-migrator.py [-h] [--skip-python-version-check] --source-uri SOURCE_URI [--target-uri TARGET_URI]
-                           [--source-database SOURCE_DATABASE] 
-                           [--duration-seconds DURATION_SECONDS]
-                           [--feedback-seconds FEEDBACK_SECONDS] [--threads THREADS]
-                           [--max-seconds-between-batches MAX_SECONDS_BETWEEN_BATCHES]
-                           [--max-operations-per-batch MAX_OPERATIONS_PER_BATCH]    
-                           [--dry-run] --start-position START_POSITION
-                           [--verbose] [--get-resume-token]
+2. Capture a change stream resume token from the source cluster. This marks the point in the change stream where replication will begin. The tool will wait until a write (insert, update, or delete) occurs on the source before it can capture a token.
 
-MVU CDC Migrator Tool.
+```terminal
+python3 mvu-cdc-migrator.py \
+  --source-uri <source-cluster-uri> \
+  --start-position 0 \
+  --get-resume-token
+```
 
-options:
-  -h, --help            show this help message and exit
-  --skip-python-version-check
-                        Permit execution on Python 3.6 and prior
-  --source-uri SOURCE_URI
-                        Source URI
-  --target-uri TARGET_URI
-                        Target URI you can skip if you run with get-resume-token
-  --source-database SOURCE_DATABASE
-                        Source database name if you skip it will replicate all the databases
-  --duration-seconds DURATION_SECONDS
-                        Number of seconds to run before exiting, 0 = run forever
-  --feedback-seconds FEEDBACK_SECONDS
-                        Number of seconds between feedback output
-  --threads THREADS     Number of threads (parallel processing)
-  --max-seconds-between-batches MAX_SECONDS_BETWEEN_BATCHES
-                        Maximum number of seconds to await full batch
-  --max-operations-per-batch MAX_OPERATIONS_PER_BATCH
-                        Maximum number of operations to include in a single batch
-  --dry-run             Read source changes only, do not apply to target
-  --start-position START_POSITION
-                        Starting position - 0 to get change stream resume token, or change stream resume token
-  --verbose             Enable verbose logging
-  --get-resume-token    Display the current change stream resume token
-```
-## Example usage:
+3. Create a snapshot of the source cluster and restore it to the target cluster. The resume token captured in step 2 ensures CDC will replay all changes that occurred after that point.
 
-* To get the cluster wide change stream token 
+4. Start the CDC replication process using the resume token from step 2:
+
+```terminal
+python3 mvu-cdc-migrator.py \
+  --source-uri <source-cluster-uri> \
+  --target-uri <target-cluster-uri> \
+  --start-position <resume-token-from-step-2> \
+  --verbose
 ```
-python3 mvu-cdc-migrator.py --source-uri <source-cluster-uri> -- start-position 0 --verbose --get-resume-token
+
+5. Monitor the "secs behind" metric in the output. Once it reaches 0 and stays there, the target is caught up and you can perform your cutover.
+
+---
+
+## Configuration
+
+The tool accepts the following arguments:
+
+| Argument | Required | Default | Description |
+| ---------- | ---------- | --------- | ------------- |
+| `--source-uri` | Yes | — | Source cluster connection URI |
+| `--start-position` | Yes | — | Change stream resume token, or `0` to get the current token |
+| `--target-uri` | No | — | Target cluster connection URI (required unless using `--get-resume-token`) |
+| `--source-database` | No | — | Source database name. If omitted, replicates all databases |
+| `--threads` | No | `1` | Total number of worker threads (hash-partitioned + dedicated). Must be greater than the number of `--single-thread-collections` |
+| `--single-thread-collections` | No | — | Comma-separated `db.collection` namespaces requiring single-threaded processing (see [Threading Model](#threading-model)) |
+| `--max-operations-per-batch` | No | `100` | Maximum operations per batch |
+| `--max-seconds-between-batches` | No | `5` | Maximum seconds to wait before processing an incomplete batch |
+| `--duration-seconds` | No | `0` | Seconds to run before exiting (`0` = run forever) |
+| `--feedback-seconds` | No | `15` | Seconds between progress output |
+| `--dry-run` | No | `false` | Read source changes only, do not apply to target |
+| `--verbose` | No | `false` | Enable verbose logging |
+| `--get-resume-token` | No | `false` | Wait for a write on the source, capture the change stream resume token, and exit |
+| `--skip-python-version-check` | No | `false` | Permit execution on Python 3.6 and prior |
+
+---
+
+## Threading Model
+
+Each worker thread opens its own change stream cursor against the source cluster and receives all events. Events are filtered locally and each thread only processes events assigned to it. This means the source cluster serves the same stream N times (once per thread), increasing read load on the source proportionally to the thread count. The parallelism benefits the write side (batching and committing to the target), not the read side.
+
+When selecting `--threads`, consider both the available vCPUs on the machine running the tool and the read capacity of the source cluster.
+
+The tool uses two types of worker threads:
+
+**Hash-partitioned pool**
+
+- Events are distributed across the hash pool based on `sha512(_id) % pool_size`. This guarantees that all events for the same document land on the same thread in order. Safe for collections where `_id` is the only unique index. The pool size equals `--threads` minus the number of `--single-thread-collections`.
+
+**Dedicated threads** (`--single-thread-collections`)
+
+- Each listed collection gets its own dedicated thread, separate from the hash pool. All events for that collection are processed sequentially in change stream order.
+
+### When to use `--single-thread-collections`
+
+Collections that have a unique index on fields OTHER than `_id` must be listed in `--single-thread-collections` when running with multiple threads.
+
+The hash-partitioned pool assigns each change stream event to a thread based on `sha512(_id) % N`. This means all events for the same `_id` always land on the same thread.
+
+**Safe case — updates to the same document (`_id` stays the same)**
+
+An application updates `{_id: A, token: "old", user: "u1"}` to `{_id: A, token: "new", user: "u1"}`. Both the before and after have `_id: A`, so both events hash to the same thread and are applied in order.
+
+**Unsafe case — compound key rotates across different `_id` values**
+
+Some workloads rotate values by deleting a document and inserting a new one with a different `_id`, but contain the same compound unique key values. For example, assume a collection with a unique index on `(token, user)` contains document `{_id: A, token: "x", user: "u1"}`. The following operations are performed, in order:
+
+- Source event 1: Delete `{_id: A, token: "x", user: "u1"}`
+- Source event 2: Insert `{_id: B, token: "x", user: "u1"}`
+
+Since these are different `_id` values, they may hash to different threads. Each thread processes its own queue independently and there is no coordination between them.
+
+The replay needs to apply the delete of `_id: A` followed by the insert of `_id: B`. But because they're on separate threads, the order is not guaranteed:
+
+| Step | Thread assigned to `_id: A` | Thread assigned to `_id: B` | Collection state |
+| --- | --- | --- | --- |
+| — | — | — | `_id: A` exists holding `(x, u1)` |
+| 1 | Queued | Attempts Insert `_id: B` - `E11000` because unique key `(x, u1)` is still held by `_id: A` | `_id: A` exists |
+| 2 | Queued | Tool skips the failed insert (see [Duplicate key handling](#duplicate-key-handling)) | `_id: A` exists |
+| 3 | Commits Delete `_id: A` - success | — | No documents (data loss) |
+
+The tool skipped the insert at step 2 because it handles all `E11000` errors as non-fatal (see [Duplicate key handling](#duplicate-key-handling) below). It cannot distinguish this cross-thread race from a legitimately safe-to-skip duplicate. The delete then removes the only remaining document.
+
+Routing these types of collections to a dedicated thread via `--single-thread-collections` guarantees that both events regardless of `_id` are processed sequentially on the same thread in change stream order. The delete executes first, freeing the compound key, followed by the insert which succeeds.
+
+### Thread layout example
+
+With `--threads 8 --single-thread-collections "mydb.device_tokens,mydb.sessions"`:
+
+| Threads | Role | Events handled |
+|---------|------|----------------|
+| 0-5 | Hash-partitioned pool | All collections NOT listed in single-thread-collections |
+| 6 | Dedicated | `mydb.device_tokens` only |
+| 7 | Dedicated | `mydb.sessions` only |
+
+Total worker processes: 8 (6 hash-partitioned + 2 dedicated).
+
+### Duplicate key handling
+
+There may be a delay between when you capture the change stream token and when you start applying changes, and during that time your application may continue to write data (insert, update, delete). During the replay of change stream events, the tool may encounter duplicate key errors (`E11000`) for documents that already exist in the restored target. The tool handles this by:
+
+1. Attempting the batch with `InsertOne`
+2. On failure, retrying with `ReplaceOne` based on `_id` (handles any `_id` conflicts)
+3. Skipping any `E11000` error operation and continuing (handles compound key conflicts from the overlap window)
+
+This skip is safe because within a single-threaded stream, the conflicting document is transient. The delete that frees the compound key always follows later in the same ordered stream.
+
+---
+
+## Example usage
+
+Capture the cluster wide change stream token:
+
+```terminal
+python3 mvu-cdc-migrator.py \
+  --source-uri <source-cluster-uri> \
+  --start-position 0 \
+  --verbose \
+  --get-resume-token
 ```
-* To Migrate the CDC changes during MVU
+
+Capture a database-level change stream token (required for database-level replication):
+
+```terminal
+python3 mvu-cdc-migrator.py \
+  --source-uri <source-cluster-uri> \
+  --source-database <database-name> \
+  --start-position 0 \
+  --verbose \
+  --get-resume-token
 ```
-python3 migrate-cdc-cluster.py --source-uri <source-cluster-uri> -- target-uri <target-cluster-uri> --start-position <change stream token> --verbose
+
+Migrate CDC changes (single-threaded):
+
+```terminal
+python3 mvu-cdc-migrator.py \
+  --source-uri <source-cluster-uri> \
+  --target-uri <target-cluster-uri> \
+  --start-position <change-stream-token> \
+  --verbose
 ```
+
+Migrate CDC changes (multi-threaded with dedicated threads for compound-key collections):
+
+```terminal
+python3 mvu-cdc-migrator.py \
+  --source-uri <source-cluster-uri> \
+  --target-uri <target-cluster-uri> \
+  --start-position <change-stream-token> \
+  --threads 8 \
+  --single-thread-collections "mydb.device_tokens,mydb.user_sessions" \
+  --verbose
+```
+
+---
+
+## Important notes
+
+- When using `--get-resume-token`, you must specify `--source-database` if you intend to run database-level replication. A cluster-level token cannot be used for database-level replication.
+- The `--start-position` token must match the scope of your replication (cluster-level token for cluster replication, database-level token for database replication).
+- Collections with unique indexes on non-`_id` fields **must** use `--single-thread-collections` when running multi-threaded. Failure to do so may result in data loss due to cross-thread ordering violations.
+
+### Stopping and restarting
+
+The tool does not perform a graceful shutdown on Ctrl+C (SIGINT). When interrupted, any in-progress batch that has not yet been committed to the target is discarded.
+
+To restart, use the last `resume token` value printed from the output. This token only updates after a batch is successfully committed to the target, so it is always safe to resume from. Events from the discarded in-progress batch will be re-read and re-applied on restart, and duplicate key handling ensures this is idempotent with no data loss.

--- a/migration/mvu-tool/mvu-cdc-migrator.py
+++ b/migration/mvu-tool/mvu-cdc-migrator.py
@@ -1,236 +1,270 @@
-from datetime import datetime, timedelta
-import os
+from datetime import datetime, timezone
 import sys
 import time
 import pymongo
-from bson.timestamp import Timestamp
+from pymongo.errors import BulkWriteError
 import threading
 import multiprocessing as mp
 import hashlib
 import argparse
 from collections import defaultdict
 
+def _execute_batch(destCollection, bulkOpList, bulkOpListReplace):
+    """Execute a batch with ordered=True, handling duplicate key errors.
 
-#Logger function
+    On initial failure (e.g. InsertOne hits existing _id), falls back to 
+    the replace list. On Error 11000 in the fallback, skips the op and 
+    continues. Safe for single-threaded replay where the conflicting
+    document is transient (will be deleted later in the same stream).
+
+    NOTE - This skip behavior is only safe when ordering is guaranteed
+    within the stream for the same compound key. Collections with unique
+    indexes on non-_id fields MUST use --single-thread-collections to
+    ensure all events for competing keys are processed in order.
+    """
+    try:
+        destCollection.bulk_write(bulkOpList, ordered=True)
+    except BulkWriteError:
+        _execute_with_dup_skip(destCollection, bulkOpListReplace)
+
+def _execute_with_dup_skip(destCollection, ops):
+    """Run ops ordered=True. On Error 11000, skip the failed op and continue."""
+    remaining = ops
+    while remaining:
+        try:
+            destCollection.bulk_write(remaining, ordered=True)
+            break
+        except BulkWriteError as bwe:
+            write_errors = bwe.details.get('writeErrors', [])
+            non_dup_errors = [e for e in write_errors if e['code'] != 11000]
+            if non_dup_errors:
+                raise
+            failed_index = write_errors[0]['index']
+            remaining = remaining[failed_index + 1:]
+
 def logIt(threadnum, message):
-    logTimeStamp = datetime.utcnow().isoformat()[:-3] + 'Z'
+    logTimeStamp = datetime.now(timezone.utc).isoformat(timespec='milliseconds').replace('+00:00', 'Z')
     print("[{}] thread {:>3d} | {}".format(logTimeStamp,threadnum,message))
 
-#Function to process the change stream
+def _open_stream(sourceConnection, appConfig, resumeToken):
+    pipeline = [
+        {'$match': {'operationType': {'$in': ['insert', 'update', 'replace', 'delete']}}},
+        {'$project': {'updateDescription': 0}}
+    ]
+    kwargs = dict(resume_after={'_data': resumeToken}, full_document='updateLookup', pipeline=pipeline)
+    if (appConfig["startTs"] == "RESUME_TOKEN") and not appConfig["sourceDb"]:
+        return sourceConnection.watch(**kwargs)
+    else:
+        return sourceConnection[appConfig["sourceDb"]].watch(**kwargs)
+
+def _new_source_connection(appConfig):
+    return pymongo.MongoClient(
+        host=appConfig["sourceUri"],
+        appname='mvutool',
+        socketTimeoutMS=30000,
+        serverSelectionTimeoutMS=30000,
+    )
+
+def _get_thread_for_event(change, appConfig):
+    """Determine which thread should process this event.
+
+    Thread layout (with --threads T and D dedicated collections):
+      0 .. (T-D-1)  = hash-partitioned pool
+      (T-D) .. (T-1) = dedicated threads (one per collection)
+
+    Collections in singleThreadCollectionMap route to their dedicated thread.
+    All other collections use hash partitioning across the pool.
+    """
+    thisNs = change['ns']['db'] + '.' + change['ns']['coll']
+    if thisNs in appConfig['singleThreadCollectionMap']:
+        return appConfig['singleThreadCollectionMap'][thisNs]
+    return int(hashlib.sha512(str(change['documentKey']).encode('utf-8')).hexdigest(), 16) % appConfig["numProcessingThreads"]
+
+def _flush_batch(destConnection, nsBulkOpDict, nsBulkOpDictReplace, numCurrentBulkOps, appConfig, perfQ, threadnum, endTs, resumeToken):
+    """Flush the current batch to the target and report progress."""
+    if not appConfig['dryRun']:
+        for ns in nsBulkOpDict:
+            destDatabase = destConnection[(ns.split('.', 1)[0])]
+            destCollection = destDatabase[(ns.split('.', 1)[1])]
+            _execute_batch(destCollection, nsBulkOpDict[ns], nsBulkOpDictReplace[ns])
+    if perfQ is not None:
+        perfQ.put({"name": "batchCompleted", "operations": numCurrentBulkOps, "endts": endTs, "processNum": threadnum, "resumeToken": resumeToken})
 
 def change_stream_processor(threadnum, appConfig, perfQ):
     if appConfig['verboseLogging']:
-        logIt(threadnum,'thread started')
+        logIt(threadnum, 'thread started')
 
-    sourceConnection = pymongo.MongoClient(host=appConfig["sourceUri"],appname='mvutool')
-    destConnection = pymongo.MongoClient(host=appConfig["targetUri"],appname='mvutool')
+    sourceConnection = _new_source_connection(appConfig)
+    destConnection = pymongo.MongoClient(
+        host=appConfig["targetUri"],
+        appname='mvutool',
+        socketTimeoutMS=30000,
+        serverSelectionTimeoutMS=30000,
+    )
     startTime = time.time()
-    lastFeedback = time.time()
     lastBatch = time.time()
     allDone = False
-    threadOplogEntries = 0
-    waitcount=0
+    waitcount = 0
     nsBulkOpDict = defaultdict(list)
-    nsBulkOpDictReplace= defaultdict(list)
-    # list with replace, not insert, in case document already exists (replaying old oplog)
+    nsBulkOpDictReplace = defaultdict(list)
     numCurrentBulkOps = 0
-    numTotalBatches = 0
     printedFirstTs = False
-    myClusterOps = 0
-
-    # starting timestamp
     endTs = appConfig["startTs"]
 
-    if (appConfig["startTs"] == "RESUME_TOKEN") and not appConfig["sourceDb"] :
-        stream = sourceConnection.watch(resume_after={'_data': appConfig["startPosition"]}, full_document='updateLookup', pipeline=[{'$match': {'operationType': {'$in': ['insert','update','replace','delete']}}},{'$project':{'updateDescription':0}}])
-        
-    else:
-        sourceDatabase=sourceConnection[appConfig["sourceDb"]]
-        stream = sourceDatabase.watch(resume_after={'_data': appConfig["startPosition"]}, full_document='updateLookup', pipeline=[{'$match': {'operationType': {'$in': ['insert','update','replace','delete']}}},{'$project':{'updateDescription':0}}])
-    
+    currentResumeToken = appConfig["startPosition"]
+    lastReportedResumeToken = currentResumeToken
 
-    if appConfig['verboseLogging']:
-        if (appConfig["startTs"] == "RESUME_TOKEN"):
-            logIt(threadnum,"Creating change stream cursor for resume token {}".format(appConfig["startPosition"]))
-    
-    while  not allDone:
-        while stream.alive:
+    if appConfig['verboseLogging'] and appConfig["startTs"] == "RESUME_TOKEN":
+        logIt(threadnum, "Creating change stream cursor for resume token {}".format(currentResumeToken))
+
+    stream = _open_stream(sourceConnection, appConfig, currentResumeToken)
+
+    while not allDone:
+        try:
+            if not stream.alive:
+                logIt(threadnum, "cursor dead, reconnecting from {}".format(currentResumeToken))
+                try:
+                    stream.close()
+                except Exception:
+                    pass
+                stream = _open_stream(sourceConnection, appConfig, currentResumeToken)
+                continue
+
             change = stream.try_next()
+
+            if stream.resume_token is not None:
+                currentResumeToken = stream.resume_token['_data']
+
             if ((time.time() - startTime) > appConfig['durationSeconds']) and (appConfig['durationSeconds'] != 0):
                 allDone = True
                 break
-            
-            # FIXED: Separate the timeout logic from change processing
+
             if change is None:
                 waitcount += 1
                 if waitcount <= appConfig["maxSecondsBetweenBatches"]:
                     time.sleep(1)
                     continue
                 else:
-                    # Timeout reached - process any pending batch and reset
                     waitcount = 0
                     if numCurrentBulkOps > 0:
-                        # Force batch processing due to timeout
                         if appConfig['verboseLogging']:
                             logIt(threadnum, f'Timeout reached, processing batch of {numCurrentBulkOps} operations')
-                        
-                        bulkOpList=[]
-                        bulkOpListReplace=[]
-                        if not appConfig['dryRun']:
-                            for ns in nsBulkOpDict:
-                                destDatabase=destConnection[(ns.split('.',1)[0])]
-                                destCollection=destDatabase[(ns.split('.',1)[1])]
-                                bulkOpList=nsBulkOpDict[ns]
-                                try:
-                                    result = destCollection.bulk_write(bulkOpList,ordered=True)
-                                except:
-                                    # replace inserts as replaces
-                                    bulkOpListReplace=nsBulkOpDictReplace[ns]
-                                    result = destCollection.bulk_write(bulkOpListReplace,ordered=True)
-                        perfQ.put({"name":"batchCompleted","operations":numCurrentBulkOps,"endts":endTs,"processNum":threadnum,"resumeToken":"N/A"})
+                        _flush_batch(destConnection, nsBulkOpDict, nsBulkOpDictReplace, numCurrentBulkOps, appConfig, perfQ, threadnum, endTs, lastReportedResumeToken)
                         nsBulkOpDict = defaultdict(list)
-                        nsBulkOpDictReplace= defaultdict(list)
+                        nsBulkOpDictReplace = defaultdict(list)
                         numCurrentBulkOps = 0
-                        numTotalBatches += 1
                         lastBatch = time.time()
                     continue
-            
-            # Reset wait count when we get a real change
+
             waitcount = 0
-            
-            # Process the actual change
+
             endTs = change['clusterTime']
             resumeToken = change['_id']['_data']
+            lastReportedResumeToken = resumeToken
             thisDb = change['ns']['db']
-            thisCol=change['ns']['coll']
-            thisNs=thisDb+'.'+thisCol
+            thisCol = change['ns']['coll']
+            thisNs = thisDb + '.' + thisCol
             thisOp = change['operationType']
-            
-            if ((int(hashlib.sha512(str(change['documentKey']).encode('utf-8')).hexdigest(), 16) % appConfig["numProcessingThreads"]) == threadnum):
-                threadOplogEntries += 1
-                if (not printedFirstTs) and (thisOp in ['insert','update','replace','delete']):
+
+            if _get_thread_for_event(change, appConfig) == threadnum:
+                if (not printedFirstTs) and (thisOp in ['insert', 'update', 'replace', 'delete']):
                     if appConfig['verboseLogging']:
-                        logIt(threadnum,'first timestamp = {} aka {}'.format(change['clusterTime'],change['clusterTime'].as_datetime()))
+                        logIt(threadnum, 'first timestamp = {} aka {}'.format(change['clusterTime'], change['clusterTime'].as_datetime()))
                     printedFirstTs = True
 
-                if (thisOp == 'insert'):
-                    myClusterOps += 1
+                if thisOp == 'insert':
                     nsBulkOpDict[thisNs].append(pymongo.InsertOne(change['fullDocument']))
-                    nsBulkOpDictReplace[thisNs].append(pymongo.ReplaceOne(change['documentKey'],change['fullDocument'],upsert=True))
+                    nsBulkOpDictReplace[thisNs].append(pymongo.ReplaceOne(change['documentKey'], change['fullDocument'], upsert=True))
                     numCurrentBulkOps += 1
-                elif (thisOp in ['update','replace']):
-                    # update/replace
-                    if (change['fullDocument'] is not None):
-                        myClusterOps += 1
-                        nsBulkOpDict[thisNs].append(pymongo.ReplaceOne(change['documentKey'],change['fullDocument'],upsert=True))
-                        nsBulkOpDictReplace[thisNs].append(pymongo.ReplaceOne(change['documentKey'],change['fullDocument'],upsert=True))
+                elif thisOp in ['update', 'replace']:
+                    if change['fullDocument'] is not None:
+                        nsBulkOpDict[thisNs].append(pymongo.ReplaceOne(change['documentKey'], change['fullDocument'], upsert=True))
+                        nsBulkOpDictReplace[thisNs].append(pymongo.ReplaceOne(change['documentKey'], change['fullDocument'], upsert=True))
                         numCurrentBulkOps += 1
-                    else:
-                        pass
-                elif (thisOp == 'delete'):
-                    myClusterOps += 1
-                    nsBulkOpDict[thisNs].append(pymongo.DeleteOne({'_id':change['documentKey']['_id']}))
-                    nsBulkOpDictReplace[thisNs].append(pymongo.DeleteOne({'_id':change['documentKey']['_id']}))
+                elif thisOp == 'delete':
+                    nsBulkOpDict[thisNs].append(pymongo.DeleteOne({'_id': change['documentKey']['_id']}))
+                    nsBulkOpDictReplace[thisNs].append(pymongo.DeleteOne({'_id': change['documentKey']['_id']}))
                     numCurrentBulkOps += 1
-                elif (thisOp in ['drop','rename','dropDatabase','invalidate']):
-                    # operations we do not track
+                elif thisOp in ['drop', 'rename', 'dropDatabase', 'invalidate']:
                     pass
                 else:
                     print(change)
                     sys.exit(1)
-            
-            # Check if we need to process batch (either by count or time)
-            if ((numCurrentBulkOps >= appConfig["maxOperationsPerBatch"]) or (time.time() >= (lastBatch + appConfig["maxSecondsBetweenBatches"])) ) and (numCurrentBulkOps > 0):
-                bulkOpList=[]
-                bulkOpListReplace=[]
-                if not appConfig['dryRun']:
-                    for ns in nsBulkOpDict:
-                        destDatabase=destConnection[(ns.split('.',1)[0])]
-                        destCollection=destDatabase[(ns.split('.',1)[1])]
-                        bulkOpList=nsBulkOpDict[ns]
-                        try:
-                            result = destCollection.bulk_write(bulkOpList,ordered=True)
-                        except:
-                            # replace inserts as replaces
-                            bulkOpListReplace=nsBulkOpDictReplace[ns]
-                            result = destCollection.bulk_write(bulkOpListReplace,ordered=True)
-                perfQ.put({"name":"batchCompleted","operations":numCurrentBulkOps,"endts":endTs,"processNum":threadnum,"resumeToken":resumeToken})
+
+            if ((numCurrentBulkOps >= appConfig["maxOperationsPerBatch"]) or (time.time() >= (lastBatch + appConfig["maxSecondsBetweenBatches"]))) and (numCurrentBulkOps > 0):
+                _flush_batch(destConnection, nsBulkOpDict, nsBulkOpDictReplace, numCurrentBulkOps, appConfig, perfQ, threadnum, endTs, resumeToken)
                 nsBulkOpDict = defaultdict(list)
-                nsBulkOpDictReplace= defaultdict(list)
+                nsBulkOpDictReplace = defaultdict(list)
                 numCurrentBulkOps = 0
-                numTotalBatches += 1
                 lastBatch = time.time()
 
-    if (numCurrentBulkOps > 0):
-        bulkOpList=[]
-        bulkOpListReplace=[]
-        print("Inside While",numCurrentBulkOps)
-        if not appConfig['dryRun']:
-            for ns in nsBulkOpDict:
-                destDatabase=destConnection[(ns.split('.',1)[0])]
-                destCollection=destDatabase[(ns.split('.',1)[1])]
-                bulkOpList=nsBulkOpDict[ns]
-                try:
-                    result = destCollection.bulk_write(bulkOpList,ordered=True)
-                except:
-                    # replace inserts as replaces
-                    bulkOpListReplace=nsBulkOpDictReplace[ns]
-                    result = destCollection.bulk_write(bulkOpListReplace,ordered=True)
-        nsBulkOpDict = defaultdict(list)
-        nsBulkOpDictReplace= defaultdict(list)
-        numCurrentBulkOps = 0
-        numTotalBatches += 1
+        except pymongo.errors.PyMongoError as e:
+            logIt(threadnum, "change stream error: {}, reconnecting in 5s from {}".format(e, currentResumeToken))
+            time.sleep(5)
+            try:
+                stream.close()
+            except Exception:
+                pass
+            try:
+                sourceConnection.close()
+            except Exception:
+                pass
+            sourceConnection = _new_source_connection(appConfig)
+            stream = _open_stream(sourceConnection, appConfig, currentResumeToken)
+
+    if numCurrentBulkOps > 0:
+        _flush_batch(destConnection, nsBulkOpDict, nsBulkOpDictReplace, numCurrentBulkOps, appConfig, None, threadnum, endTs, None)
 
     sourceConnection.close()
     destConnection.close()
-    perfQ.put({"name":"processCompleted","processNum":threadnum})
+    perfQ.put({"name": "processCompleted", "processNum": threadnum})
 
-#Function to get the Change stream token
 def get_resume_token(appConfig):
     sourceConnection = pymongo.MongoClient(host=appConfig["sourceUri"],appname='mvutool')
-    
-    allDone = False
-    if not appConfig["sourceDb"]:
-        stream = sourceConnection.watch()
-        logIt(-1,'getting current change stream resume token')
-    else:
-        sourceDatabase=sourceConnection[appConfig["sourceDb"]]
-        stream=sourceDatabase.watch()
-        logIt(-1,'getting current change stream resume token for ' + appConfig["sourceDb"] + " database")
+    try:
+        if not appConfig["sourceDb"]:
+            stream = sourceConnection.watch()
+            logIt(-1,'getting current change stream resume token')
+        else:
+            sourceDatabase=sourceConnection[appConfig["sourceDb"]]
+            stream=sourceDatabase.watch()
+            logIt(-1,'getting current change stream resume token for ' + appConfig["sourceDb"] + " database")
 
-    while not allDone:
-        for change in stream:
-            resumeToken = change['_id']['_data']
-            logIt(-1,'Change stream resume token is {}'.format(resumeToken))
-            filename="get-resume-token-"+time.strftime("%Y%m%d-%H%M%S")+".txt"
-            f = open(filename, "w")
-            f.write("Change stream resume token is "+ str(resumeToken))
-            f.close()
-            allDone = True
-            break
-
+        logIt(-1,'waiting for a write operation on the source to capture a token...')
+        waitStart = time.time()
+        while True:
+            change = stream.try_next()
+            if change is not None:
+                resumeToken = change['_id']['_data']
+                logIt(-1,'resume token: {}'.format(resumeToken))
+                break
+            elapsed = int(time.time() - waitStart)
+            if elapsed > 0 and elapsed % 30 == 0:
+                logIt(-1,'still waiting ({} seconds). A write (insert/update/delete) must occur on the source to generate a token.'.format(elapsed))
+            time.sleep(1)
+    finally:
+        sourceConnection.close()
 
 def reporter(appConfig, perfQ):
     if appConfig['verboseLogging']:
         logIt(-1,'reporting thread started')
-    
+
     startTime = time.time()
     lastTime = time.time()
-    
+
     lastProcessedOplogEntries = 0
-    nextReportTime = startTime + appConfig["feedbackSeconds"]
 
     resumeToken = 'N/A'
 
     numWorkersCompleted = 0
     numProcessedOplogEntries = 0
-    
+
     dtDict = {}
-    
-    while (numWorkersCompleted < appConfig["numProcessingThreads"]):
+
+    while (numWorkersCompleted < appConfig["totalWorkers"]):
         time.sleep(appConfig["feedbackSeconds"])
         nowTime = time.time()
-        
+
         while not perfQ.empty():
             qMessage = perfQ.get_nowait()
             if qMessage['name'] == "batchCompleted":
@@ -241,45 +275,34 @@ def reporter(appConfig, perfQ):
                     dtDict[thisProcessNum] = thisEndDt
                 else:
                     dtDict[thisProcessNum] = thisEndDt
-                #print("received endTs = {}".format(thisEndTs.as_datetime()))
-                if 'resumeToken' in qMessage:
+                if qMessage.get('resumeToken') and qMessage['resumeToken'] != 'N/A':
                     resumeToken = qMessage['resumeToken']
-                else:
-                    resumeToken = 'N/A'
 
             elif qMessage['name'] == "processCompleted":
                 numWorkersCompleted += 1
 
-        # total total
         elapsedSeconds = nowTime - startTime
         totalOpsPerSecond = numProcessedOplogEntries / elapsedSeconds
 
-        # elapsed hours, minutes, seconds
         thisHours, rem = divmod(elapsedSeconds, 3600)
         thisMinutes, thisSeconds = divmod(rem, 60)
         thisHMS = "{:0>2}:{:0>2}:{:05.2f}".format(int(thisHours),int(thisMinutes),thisSeconds)
-        
-        # this interval
+
         intervalElapsedSeconds = nowTime - lastTime
         intervalOpsPerSecond = (numProcessedOplogEntries - lastProcessedOplogEntries) / intervalElapsedSeconds
-        
-        # how far behind current time
-        dtUtcNow = datetime.utcnow()
-        totSecondsBehind = 0
-        numSecondsBehindEntries = 0
+
+        dtUtcNow = datetime.now(timezone.utc).replace(tzinfo=None)
+        secsBehind = 0
         for thisDt in dtDict:
-            totSecondsBehind = (dtUtcNow - dtDict[thisDt].replace(tzinfo=None)).total_seconds()
-            numSecondsBehindEntries += 1
+            secondsBehind = (dtUtcNow - dtDict[thisDt].replace(tzinfo=None)).total_seconds()
+            secsBehind = max(secsBehind, secondsBehind)
+        secsBehind = int(secsBehind)
 
-        avgSecondsBehind = int(totSecondsBehind / max(numSecondsBehindEntries,1))
+        logTimeStamp = datetime.now(timezone.utc).isoformat(timespec='milliseconds').replace('+00:00', 'Z')
+        print("[{0}] elapsed {1} | total o/s {2:12,.2f} | interval o/s {3:12,.2f} | tot {4:16,d} | {5:12,d} secs behind | resume token = {6}".format(logTimeStamp,thisHMS,totalOpsPerSecond,intervalOpsPerSecond,numProcessedOplogEntries,secsBehind,resumeToken))
 
-        logTimeStamp = datetime.utcnow().isoformat()[:-3] + 'Z'
-        print("[{0}] elapsed {1} | total o/s {2:12,.2f} | interval o/s {3:12,.2f} | tot {4:16,d} | {5:12,d} secs behind | resume token = {6}".format(logTimeStamp,thisHMS,totalOpsPerSecond,intervalOpsPerSecond,numProcessedOplogEntries,avgSecondsBehind,resumeToken))
-        nextReportTime = nowTime + appConfig["feedbackSeconds"]
-        
         lastTime = nowTime
         lastProcessedOplogEntries = numProcessedOplogEntries
-
 
 def main():
     parser = argparse.ArgumentParser(description='MVU CDC Migrator Tool.')
@@ -288,7 +311,7 @@ def main():
                         required=False,
                         action='store_true',
                         help='Permit execution on Python 3.6 and prior')
-    
+
     parser.add_argument('--source-uri',
                         required=True,
                         type=str,
@@ -304,8 +327,8 @@ def main():
                         required=False,
                         type=str,
                         help='Source database name if you skip it will replicate all the databases')
-                        
-                      
+
+
     parser.add_argument('--duration-seconds',
                         required=False,
                         type=int,
@@ -335,7 +358,7 @@ def main():
                         type=int,
                         default=100,
                         help='Maximum number of operations to include in a single batch')
-                        
+
     parser.add_argument('--dry-run',
                         required=False,
                         action='store_true',
@@ -356,17 +379,26 @@ def main():
                         action='store_true',
                         help='Display the current change stream resume token')
 
+    parser.add_argument('--single-thread-collections',
+                        required=False,
+                        type=str,
+                        default='',
+                        help='Comma-separated list of db.collection namespaces that require '
+                             'single-threaded processing. Each collection gets its own dedicated '
+                             'thread, separate from the hash-partitioned pool. Required for '
+                             'collections with unique indexes on non-_id fields when running '
+                             'with multiple threads. '
+                             'Example: mydb.device_tokens,mydb.user_sessions')
+
     args = parser.parse_args()
 
     MIN_PYTHON = (3, 7)
     if (not args.skip_python_version_check) and (sys.version_info < MIN_PYTHON):
         sys.exit("\nPython %s.%s or later is required.\n" % MIN_PYTHON)
 
-
     appConfig = {}
     appConfig['sourceUri'] = args.source_uri
     appConfig['targetUri'] = args.target_uri
-    appConfig['numProcessingThreads'] = args.threads
     appConfig['maxSecondsBetweenBatches'] = args.max_seconds_between_batches
     appConfig['maxOperationsPerBatch'] = args.max_operations_per_batch
     appConfig['durationSeconds'] = args.duration_seconds
@@ -376,6 +408,20 @@ def main():
     appConfig['startPosition'] = args.start_position
     appConfig['verboseLogging'] = args.verbose
     appConfig['cdcSource'] = 'changeStream'
+    singleThreadList = [ns.strip() for ns in args.single_thread_collections.split(',') if ns.strip()]
+    numDedicated = len(singleThreadList)
+    numHashThreads = args.threads - numDedicated
+    if numHashThreads < 1:
+        parser.error(
+            "--threads must be greater than the number of --single-thread-collections. "
+            "You specified {} threads and {} single-thread collections, leaving no threads "
+            "for the hash-partitioned pool.".format(args.threads, numDedicated)
+        )
+    appConfig['numProcessingThreads'] = numHashThreads
+    appConfig['singleThreadCollectionMap'] = {
+        ns: numHashThreads + i for i, ns in enumerate(singleThreadList)
+    }
+    appConfig['totalWorkers'] = args.threads
 
     if args.get_resume_token:
         get_resume_token(appConfig)
@@ -383,33 +429,48 @@ def main():
     elif (not args.get_resume_token) and args.target_uri =='no-target-uri':
         message = "you need to supply target uri to run it"
         parser.error(message)
-  
-    logIt(-1,"processing {} using {} threads".format(appConfig['cdcSource'],appConfig['numProcessingThreads']))
 
-    if len(appConfig["startPosition"]) == 36:
-        # resume token
+    logIt(-1,"processing {} using {} total threads ({} hash-partitioned, {} dedicated)".format(
+        appConfig['cdcSource'], appConfig['totalWorkers'],
+        appConfig['numProcessingThreads'], len(appConfig['singleThreadCollectionMap'])))
+
+    if appConfig['singleThreadCollectionMap']:
+        for ns, tid in sorted(appConfig['singleThreadCollectionMap'].items(), key=lambda x: x[1]):
+            logIt(-1,"  thread {} -> {}".format(tid, ns))
+
+    if appConfig["startPosition"] == "0":
+        parser.error(
+            "--start-position 0 is only valid with --get-resume-token. "
+            "To start replication, provide a 36-character resume token."
+        )
+    elif len(appConfig["startPosition"]) == 36:
         appConfig["startTs"] = "RESUME_TOKEN"
         logIt(-1,"starting with resume token = {}".format(appConfig["startPosition"]))
+    else:
+        parser.error(
+            "Invalid --start-position value. Expected a 36-character resume token, "
+            "got {} characters. Use --get-resume-token to obtain a valid token.".format(
+                len(appConfig["startPosition"]))
+        )
 
     mp.set_start_method('spawn')
     q = mp.Manager().Queue()
 
     t = threading.Thread(target=reporter,args=(appConfig,q))
     t.start()
-    
+
     processList = []
-    for loop in range(appConfig["numProcessingThreads"]):
+    for loop in range(appConfig["totalWorkers"]):
         p = mp.Process(target=change_stream_processor,args=(loop,appConfig,q))
         processList.append(p)
-        
+
     for process in processList:
         process.start()
-        
+
     for process in processList:
         process.join()
-        
-    t.join()
 
+    t.join()
 
 if __name__ == "__main__":
     main()

--- a/migration/mvu-tool/test_mvu_cdc_migrator.py
+++ b/migration/mvu-tool/test_mvu_cdc_migrator.py
@@ -1,0 +1,442 @@
+# Unit tests for mvu-cdc-migrator.py
+
+import hashlib
+import sys
+import os
+from unittest.mock import MagicMock
+import pytest
+import pymongo
+from pymongo.errors import BulkWriteError
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import importlib.util
+spec = importlib.util.spec_from_file_location("mvu_cdc_migrator", os.path.join(os.path.dirname(__file__), "mvu-cdc-migrator.py"))
+mvu = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mvu)
+
+# Fixtures
+def make_appconfig(threads=4, single_thread_collections=None):
+    """Build a minimal appConfig for testing.
+
+    threads = total thread count (same as --threads CLI arg).
+    single_thread_collections = dict of ns -> thread_id (already computed).
+    numProcessingThreads = hash pool size = threads - len(dedicated).
+    """
+    single_thread_collections = single_thread_collections or {}
+    num_dedicated = len(single_thread_collections)
+    return {
+        'numProcessingThreads': threads - num_dedicated,
+        'singleThreadCollectionMap': single_thread_collections,
+    }
+
+def make_change_event(db='testdb', coll='testcol', doc_key=None, op_type='insert', full_document=None):
+    """Build a synthetic change stream event."""
+    if doc_key is None:
+        doc_key = {'_id': 'abc123'}
+    event = {
+        'ns': {'db': db, 'coll': coll},
+        'documentKey': doc_key,
+        'operationType': op_type,
+        '_id': {'_data': 'resume_token_xyz'},
+        'clusterTime': MagicMock(),
+    }
+    if full_document is not None:
+        event['fullDocument'] = full_document
+    return event
+
+def make_bulk_write_error(error_list, n_inserted=0):
+    """Create a BulkWriteError with specified error codes."""
+    details = {
+        'writeErrors': error_list,
+        'nInserted': n_inserted,
+        'nMatched': 0,
+        'nRemoved': 0,
+    }
+    return BulkWriteError(details)
+
+# Test - _get_thread_for_event
+class TestGetThreadForEvent:
+    def test_hash_partitioned_collection(self):
+        """Non-single-thread collections route by hash of documentKey."""
+        appConfig = make_appconfig(threads=4)
+        change = make_change_event(doc_key={'_id': 'doc1'})
+
+        result = mvu._get_thread_for_event(change, appConfig)
+
+        expected = int(hashlib.sha512(str({'_id': 'doc1'}).encode('utf-8')).hexdigest(), 16) % 4
+        assert result == expected
+
+    def test_single_thread_collection_routes_to_dedicated(self):
+        """Collections in singleThreadCollectionMap route to their dedicated thread."""
+        # 6 total, 2 dedicated - hash pool = 4 (threads 0-3), dedicated = 4, 5
+        appConfig = make_appconfig(threads=6, single_thread_collections={
+            'mydb.device_tokens': 4,
+            'mydb.sessions': 5,
+        })
+        change = make_change_event(db='mydb', coll='device_tokens')
+
+        result = mvu._get_thread_for_event(change, appConfig)
+
+        assert result == 4
+
+    def test_single_thread_second_collection(self):
+        """Second single-thread collection gets the next dedicated thread."""
+        # 6 total, 2 dedicated - hash pool = 4 (threads 0-3), dedicated = 4, 5
+        appConfig = make_appconfig(threads=6, single_thread_collections={
+            'mydb.device_tokens': 4,
+            'mydb.sessions': 5,
+        })
+        change = make_change_event(db='mydb', coll='sessions')
+
+        result = mvu._get_thread_for_event(change, appConfig)
+
+        assert result == 5
+
+    def test_non_single_thread_same_db(self):
+        """A collection in the same db but not listed uses hash routing."""
+        # 5 total, 1 dedicated - hash pool = 4 (threads 0-3), dedicated = 4
+        appConfig = make_appconfig(threads=5, single_thread_collections={
+            'mydb.device_tokens': 4,
+        })
+        change = make_change_event(db='mydb', coll='other_collection', doc_key={'_id': 'x'})
+
+        result = mvu._get_thread_for_event(change, appConfig)
+
+        expected = int(hashlib.sha512(str({'_id': 'x'}).encode('utf-8')).hexdigest(), 16) % 4
+        assert result == expected
+
+    def test_hash_partitioning_deterministic(self):
+        """Same documentKey always routes to the same thread."""
+        appConfig = make_appconfig(threads=8)
+        change = make_change_event(doc_key={'_id': 'consistent_doc'})
+
+        results = [mvu._get_thread_for_event(change, appConfig) for _ in range(100)]
+
+        assert len(set(results)) == 1
+
+    def test_hash_partitioning_distributes(self):
+        """Different documentKeys distribute across threads."""
+        appConfig = make_appconfig(threads=4)
+        threads_hit = set()
+        for i in range(100):
+            change = make_change_event(doc_key={'_id': f'doc_{i}'})
+            threads_hit.add(mvu._get_thread_for_event(change, appConfig))
+
+        assert len(threads_hit) > 1
+
+    def test_dedicated_thread_ids_never_overlap_hash_pool(self):
+        """Dedicated thread IDs are always >= numProcessingThreads (hash pool size)."""
+        # 8 total threads, 3 dedicated - hash pool is 5 (threads 0-4), dedicated are 5,6,7
+        appConfig = make_appconfig(threads=8, single_thread_collections={
+            'db.col1': 5,
+            'db.col2': 6,
+            'db.col3': 7,
+        })
+
+        for ns, tid in appConfig['singleThreadCollectionMap'].items():
+            assert tid >= appConfig['numProcessingThreads']
+
+        for i in range(200):
+            change = make_change_event(db='db', coll=f'normal_{i}', doc_key={'_id': f'id_{i}'})
+            thread = mvu._get_thread_for_event(change, appConfig)
+            assert thread < appConfig['numProcessingThreads']
+
+# Test - _execute_batch
+class TestExecuteBatch:
+    def test_success_on_primary_path(self):
+        """When primary bulk_write succeeds, no fallback needed."""
+        collection = MagicMock()
+        primary_ops = [pymongo.InsertOne({'_id': 1, 'x': 'a'})]
+        fallback_ops = [pymongo.ReplaceOne({'_id': 1}, {'_id': 1, 'x': 'a'}, upsert=True)]
+
+        mvu._execute_batch(collection, primary_ops, fallback_ops)
+
+        collection.bulk_write.assert_called_once_with(primary_ops, ordered=True)
+
+    def test_fallback_on_primary_failure(self):
+        """When primary fails with BulkWriteError, falls back to replace list."""
+        collection = MagicMock()
+        bwe = make_bulk_write_error([{'index': 0, 'code': 11000, 'errmsg': 'dup'}])
+        collection.bulk_write.side_effect = [bwe, MagicMock()]
+
+        primary_ops = [pymongo.InsertOne({'_id': 1})]
+        fallback_ops = [pymongo.ReplaceOne({'_id': 1}, {'_id': 1}, upsert=True)]
+
+        mvu._execute_batch(collection, primary_ops, fallback_ops)
+
+        assert collection.bulk_write.call_count == 2
+        collection.bulk_write.assert_called_with(fallback_ops, ordered=True)
+
+    def test_non_bulk_write_error_propagates(self):
+        """Non-BulkWriteError exceptions from primary path propagate."""
+        collection = MagicMock()
+        collection.bulk_write.side_effect = pymongo.errors.ServerSelectionTimeoutError('timeout')
+
+        with pytest.raises(pymongo.errors.ServerSelectionTimeoutError):
+            mvu._execute_batch(collection, [pymongo.InsertOne({'_id': 1})], [])
+
+# Test - _execute_with_dup_skip
+class TestExecuteWithDupSkip:
+    def test_no_error(self):
+        """Clean batch succeeds on first try."""
+        collection = MagicMock()
+        ops = [pymongo.ReplaceOne({'_id': 1}, {'_id': 1}, upsert=True)]
+
+        mvu._execute_with_dup_skip(collection, ops)
+
+        collection.bulk_write.assert_called_once_with(ops, ordered=True)
+
+    def test_single_dup_key_skipped(self):
+        """A single 11000 error is skipped, remaining ops continue."""
+        collection = MagicMock()
+        ops = [
+            pymongo.ReplaceOne({'_id': 1}, {'_id': 1}, upsert=True),
+            pymongo.DeleteOne({'_id': 2}),
+            pymongo.ReplaceOne({'_id': 3}, {'_id': 3}, upsert=True),
+        ]
+        bwe = make_bulk_write_error([{'index': 0, 'code': 11000, 'errmsg': 'dup'}])
+        collection.bulk_write.side_effect = [bwe, MagicMock()]
+
+        mvu._execute_with_dup_skip(collection, ops)
+
+        assert collection.bulk_write.call_count == 2
+        # Second call should be ops[1:] (skipped index 0)
+        collection.bulk_write.assert_called_with(ops[1:], ordered=True)
+
+    def test_multiple_dup_keys_skipped_sequentially(self):
+        """Multiple 11000 errors at different positions are each skipped."""
+        collection = MagicMock()
+        ops = [
+            pymongo.ReplaceOne({'_id': 1}, {'_id': 1}, upsert=True),
+            pymongo.ReplaceOne({'_id': 2}, {'_id': 2}, upsert=True),
+            pymongo.ReplaceOne({'_id': 3}, {'_id': 3}, upsert=True),
+        ]
+        # First call fails at index 0, second call (ops[1:]) fails at index 0 (which is original index 1)
+        bwe1 = make_bulk_write_error([{'index': 0, 'code': 11000, 'errmsg': 'dup'}])
+        bwe2 = make_bulk_write_error([{'index': 0, 'code': 11000, 'errmsg': 'dup'}])
+        collection.bulk_write.side_effect = [bwe1, bwe2, MagicMock()]
+
+        mvu._execute_with_dup_skip(collection, ops)
+
+        assert collection.bulk_write.call_count == 3
+        collection.bulk_write.assert_called_with([ops[2]], ordered=True)
+
+    def test_non_dup_error_raises(self):
+        """Non-11000 errors cause the exception to propagate."""
+        collection = MagicMock()
+        ops = [pymongo.ReplaceOne({'_id': 1}, {'_id': 1}, upsert=True)]
+        bwe = make_bulk_write_error([{'index': 0, 'code': 121, 'errmsg': 'validation failed'}])
+        collection.bulk_write.side_effect = bwe
+
+        with pytest.raises(BulkWriteError):
+            mvu._execute_with_dup_skip(collection, ops)
+
+    def test_mixed_errors_raises_on_non_dup(self):
+        """If any error is non-11000, raise even if others are 11000."""
+        collection = MagicMock()
+        ops = [pymongo.ReplaceOne({'_id': 1}, {'_id': 1}, upsert=True)]
+        bwe = make_bulk_write_error([
+            {'index': 0, 'code': 11000, 'errmsg': 'dup'},
+            {'index': 1, 'code': 50, 'errmsg': 'timeout'},
+        ])
+        collection.bulk_write.side_effect = bwe
+
+        with pytest.raises(BulkWriteError):
+            mvu._execute_with_dup_skip(collection, ops)
+
+    def test_empty_ops_list(self):
+        """Empty ops list does nothing."""
+        collection = MagicMock()
+
+        mvu._execute_with_dup_skip(collection, [])
+
+        collection.bulk_write.assert_not_called()
+
+    def test_all_ops_are_dup_keys(self):
+        """If every op fails with 11000, all are skipped gracefully."""
+        collection = MagicMock()
+        ops = [
+            pymongo.ReplaceOne({'_id': 1}, {'_id': 1}, upsert=True),
+            pymongo.ReplaceOne({'_id': 2}, {'_id': 2}, upsert=True),
+        ]
+        bwe1 = make_bulk_write_error([{'index': 0, 'code': 11000, 'errmsg': 'dup'}])
+        bwe2 = make_bulk_write_error([{'index': 0, 'code': 11000, 'errmsg': 'dup'}])
+        collection.bulk_write.side_effect = [bwe1, bwe2]
+
+        mvu._execute_with_dup_skip(collection, ops)
+
+        assert collection.bulk_write.call_count == 2
+
+# Test - Snapshot overlap with compound unique index
+class TestSnapshotOverlapCompoundKey:
+    """Simulates CDC replay when a resume token is captured before a snapshot,
+    creating an overlap window where events are present in both the snapshot
+    and the change stream.
+
+    If a compound unique index exists (e.g. token + user) and a
+    document is inserted then deleted then re-inserted with a new _id
+    during the overlap window, the snapshot will contain the final _id.
+    When CDC replays from the resume token, the first insert attempts to
+    create a document whose compound key is already held by the snapshot
+    document (different _id). Both the InsertOne and the ReplaceOne
+    fallback (upsert=True) fail with E11000 because the upsert becomes
+    an insert when _id doesn't match. The handler should skip past the
+    conflicting op and continue processing the rest of the batch.
+    """
+
+    def test_replay_skips_transient_insert_and_processes_rest(self):
+        """Transient insert from overlap window is skipped, remaining ops succeed."""
+        collection = MagicMock()
+
+        # Batch as it would be assembled by change_stream_processor
+        primary_ops = [
+            pymongo.InsertOne({'_id': 1, 'token': 'abc', 'user': 'u1'}),
+            pymongo.DeleteOne({'_id': 1}),
+            pymongo.InsertOne({'_id': 2, 'token': 'abc', 'user': 'u1'}),
+        ]
+        fallback_ops = [
+            pymongo.ReplaceOne({'_id': 1}, {'_id': 1, 'token': 'abc', 'user': 'u1'}, upsert=True),
+            pymongo.DeleteOne({'_id': 1}),
+            pymongo.ReplaceOne({'_id': 2}, {'_id': 2, 'token': 'abc', 'user': 'u1'}, upsert=True),
+        ]
+
+        # Primary fails on first insert (compound key violation)
+        primary_bwe = make_bulk_write_error([{'index': 0, 'code': 11000, 'errmsg': 'dup key'}])
+        # Fallback: first ReplaceOne also fails (upsert on _id:1 hits compound key)
+        fallback_bwe = make_bulk_write_error([{'index': 0, 'code': 11000, 'errmsg': 'dup key'}])
+
+        collection.bulk_write.side_effect = [
+            primary_bwe,      # primary path fails
+            fallback_bwe,     # fallback: first op fails with 11000
+            MagicMock(),      # fallback resumed: delete + replace succeed
+        ]
+
+        mvu._execute_batch(collection, primary_ops, fallback_ops)
+
+        assert collection.bulk_write.call_count == 3
+        # Final call should be the remaining ops after skipping index 0
+        final_call_ops = collection.bulk_write.call_args_list[2][0][0]
+        assert len(final_call_ops) == 2  # delete + replace
+
+# Tests - Thread routing guarantees with compound keys
+class TestCompoundKeyThreadSafety:
+    """Validates that the dedicated thread model prevents cross-thread races."""
+
+    def test_same_compound_key_different_ids_same_dedicated_thread(self):
+        """Two docs sharing compound key in a single-thread collection
+        always route to the same thread regardless of _id."""
+        # 8 total threads, 1 dedicated - hash pool = 7 (threads 0-6), dedicated = 7
+        appConfig = make_appconfig(threads=8, single_thread_collections={
+            'mydb.device_tokens': 7,
+        })
+
+        change_a = make_change_event(db='mydb', coll='device_tokens', doc_key={'_id': 'id_A'})
+        change_b = make_change_event(db='mydb', coll='device_tokens', doc_key={'_id': 'id_B'})
+
+        thread_a = mvu._get_thread_for_event(change_a, appConfig)
+        thread_b = mvu._get_thread_for_event(change_b, appConfig)
+
+        assert thread_a == thread_b == 7
+
+    def test_same_compound_key_different_ids_hash_pool_may_differ(self):
+        """Without single-thread, different _ids CAN land on different threads.
+        This demonstrates why --single-thread-collections is needed."""
+        appConfig = make_appconfig(threads=8)
+
+        # Find two _ids that hash to different threads
+        threads_seen = {}
+        for i in range(1000):
+            doc_key = {'_id': f'token_rotation_{i}'}
+            change = make_change_event(db='mydb', coll='device_tokens', doc_key=doc_key)
+            t = mvu._get_thread_for_event(change, appConfig)
+            if t not in threads_seen:
+                threads_seen[t] = doc_key
+            if len(threads_seen) >= 2:
+                break
+
+        # Proves that hash partitioning splits different _ids across threads
+        assert len(threads_seen) >= 2, "Expected different _ids to route to different threads"
+
+# Test - appConfig construction (validates CLI parsing logic)
+class TestAppConfigConstruction:
+    def test_single_thread_collection_map_empty_by_default(self):
+        """No --single-thread-collections means empty map, all threads are hash pool."""
+        threads = 4
+        single_thread_arg = ''
+        ns_list = [x.strip() for x in single_thread_arg.split(',') if x.strip()]
+        num_hash = threads - len(ns_list)
+        result = {ns: num_hash + i for i, ns in enumerate(ns_list)}
+        assert result == {}
+        assert num_hash == 4
+
+    def test_single_thread_collection_map_single_entry(self):
+        """One dedicated collection is carved from the total thread count."""
+        single_thread_arg = 'mydb.device_tokens'
+        threads = 4
+        ns_list = [x.strip() for x in single_thread_arg.split(',') if x.strip()]
+        num_hash = threads - len(ns_list)  # 3 hash threads
+        result = {ns: num_hash + i for i, ns in enumerate(ns_list)}
+        assert result == {'mydb.device_tokens': 3}
+        assert num_hash == 3
+
+    def test_single_thread_collection_map_multiple_entries(self):
+        """Multiple dedicated collections are carved from total, leaving the rest for hash."""
+        single_thread_arg = 'mydb.device_tokens, mydb.sessions, mydb.auth_codes'
+        threads = 8
+        ns_list = [x.strip() for x in single_thread_arg.split(',') if x.strip()]
+        num_hash = threads - len(ns_list)  # 5 hash threads
+        result = {ns: num_hash + i for i, ns in enumerate(ns_list)}
+        assert result == {
+            'mydb.device_tokens': 5,
+            'mydb.sessions': 6,
+            'mydb.auth_codes': 7,
+        }
+        assert num_hash == 5
+
+    def test_total_workers_equals_threads_arg(self):
+        """totalWorkers equals --threads (dedicated are carved from it, not added)."""
+        threads = 8
+        total_workers = threads
+        assert total_workers == 8
+
+# Test - Edge cases in event routing
+class TestEventRoutingEdgeCases:
+    def test_namespace_matching_is_exact(self):
+        """db.collection must match exactly."""
+        # 5 total, 1 dedicated - hash pool = 4 (threads 0-3), dedicated = 4
+        appConfig = make_appconfig(threads=5, single_thread_collections={
+            'mydb.device_tokens': 4,
+        })
+
+        # Similar name but different collection
+        change = make_change_event(db='mydb', coll='device_tokens_archive', doc_key={'_id': '1'})
+        result = mvu._get_thread_for_event(change, appConfig)
+
+        # Should NOT route to dedicated thread
+        assert result != 4
+        expected = int(hashlib.sha512(str({'_id': '1'}).encode('utf-8')).hexdigest(), 16) % 4
+        assert result == expected
+
+    def test_different_db_same_collection_name(self):
+        """db1.tokens and db2.tokens are different namespaces."""
+        # 5 total, 1 dedicated - hash pool = 4 (threads 0-3), dedicated = 4
+        appConfig = make_appconfig(threads=5, single_thread_collections={
+            'db1.tokens': 4,
+        })
+
+        change_db2 = make_change_event(db='db2', coll='tokens', doc_key={'_id': '1'})
+        result = mvu._get_thread_for_event(change_db2, appConfig)
+
+        assert result != 4  # not routed to db1.tokens dedicated thread
+
+    def test_single_thread_mode_all_events_to_thread_zero(self):
+        """With --threads 1 and no single-thread-collections, everything goes to thread 0."""
+        appConfig = make_appconfig(threads=1)
+
+        for i in range(50):
+            change = make_change_event(doc_key={'_id': f'doc_{i}'})
+            assert mvu._get_thread_for_event(change, appConfig) == 0
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
# Summary

Overhauls the MVU CDC migrator to address data integrity issues with collections that have unique indexes on non-`_id` fields, adds a dedicated threading model for those collections, and fixes several correctness/usability bugs.

Customer testing revealed that the existing tool hangs or silently loses data when replicating collections with compound unique indexes. The root cause is two-fold:

1. Snapshot overlap window - When the resume token is captured before the snapshot, CDC replays events that already exist in the restored target. Compound unique key conflicts cause `ordered=True` batches to halt permanently.

2. Cross-thread ordering violation - The hash-partitioned threading model routes by `_id`. Two documents with different `_id` values but the same compound unique key can land on different threads. If the insert thread commits before the delete thread, the insert fails and the tool has no way to distinguish this from a benign overlap conflict. Skipping it results in data loss.

## Changes

### (NEW) Dedicated thread model (`--single-thread-collections`)

- Collections with compound unique indexes can be routed to their own dedicated thread, guaranteeing change stream ordering regardless of `_id`.
- Dedicated threads are carved from the `--threads` total so the total process count matches the resource expectations.
- Validation rejects configurations with insufficient threads for the hash pool.

### (NEW) Duplicate key error handling (`_execute_batch`, `_execute_with_dup_skip`)

- Primary path remains `InsertOne` with `ordered=True`.
- The fallback is `ReplaceOne` with `ordered=True` based on `_id` (handles `_id` conflicts).
- On `E11000` errors during the fallback, it will now skip that operation and resume from the next index (handles compound key conflicts from the overlap window).
- Non-`11000` errors propagate immediately.

### (NEW) Automatic reconnection

- Catches PyMongoError in the main loop, logs, sleeps 5s, and reconnects from the tracked resume token.
- Tracks `stream.resume_token` after every `try_next()` poll for accurate reconnection position.
- Detects dead cursors via `stream.alive` check.

### (FIXED) Seconds-behind metric

- Was overwriting instead of accumulating across threads and only showed the lag of whichever thread iterated last.
- Now reports max lag across all threads.

### (FIXED) `get_resume_token` blocking behavior

- Previously blocked forever with no feedback if no writes occurred on the source.
- Now polls with `try_next()` and prints a reminder every 30 seconds explaining a write is needed.
- Connection is properly closed via `try`/`finally`.

### (FIXED) Start position validation

- `--start-position 0` without `--get-resume-token` now errors with a clear message instead of crashing later.
- Non-36-character tokens are rejected with guidance.

### (REMOVED) Dead code

- `myClusterOps`, `threadOplogEntries`, `numTotalBatches`, `nextReportTime` were incremented but never read.
- Debug `print("Inside While", ...)` statement (appears to be a leftover from testing/development).
- File write in `get_resume_token` (token is printed to `stdout` and the file was never used by the tool).

### Other

- Modernized datetime usage (`datetime.now(timezone.utc)` instead of deprecated `datetime.utcnow()`).
- Connection timeouts (`socketTimeoutMS=30000`, `serverSelectionTimeoutMS=30000`).
- Extracted `_open_stream` and `_new_source_connection` helpers.
- Replaced bare except with except `BulkWriteError:` / `except Exception:`.

### Performance trade-offs

| Area | Impact | Reasoning |
| --- | --- | --- |
| Hash pool size | Reduced by number of dedicated collections | Dedicated threads are carved from `--threads` total. Users who previously ran `--threads 8` with no dedicated collections get the same throughput. Users adding dedicated collections lose hash pool parallelism proportionally. Increase `--threads` to compensate. |
| Overlap window replay | Slower per-batch during overlap | Each `E11000` error in the skip loop costs a server round trip. With high write throughput and many conflicts, batches during the overlap window may take 10-50× longer. This is finite (ends once replay passes the overlap window) and the alternative was hanging forever. |
| N× source read amplification | Unchanged (same as original) | Each thread opens its own change stream cursor. Documented in README. |
| `_get_thread_for_event` | Adds dict lookup + function call per event | Negligible vs network I/O for stream read and batch write. |

### Testing

Added `test_mvu_cdc_migrator.py` with 27 unit tests covering:

- Thread routing (hash partitioning, dedicated threads, namespace matching, non-overlap guarantees)
- Batch execution (primary path, fallback, error propagation)
- Duplicate key skip logic (single skip, sequential skips, non-dup errors, empty ops, all-dup)
- Snapshot overlap scenario (transient insert skipped, remaining ops succeed)
- Config construction (thread map calculation, total worker count)
