### PR TITLE
compat-tool: normalize Kotlin/Groovy template string escapes in code scan

### DIFF
--- a/compat-tool/compat.py
+++ b/compat-tool/compat.py
@@ -130,6 +130,8 @@ def scan_code(args, keywords):
             fileLineNum = 1
             
             for lineNum, thisLine in enumerate(fileLines):
+                # Normalize Kotlin/Groovy template string escapes: ${'$'} -> $
+                thisLine = thisLine.replace("${'$'}", "$")
                 thisLineLength = len(thisLine)
                 
                 for checkCompat in keywords:


### PR DESCRIPTION
## Problem

The `scan_code` function in `compat.py` fails to detect unsupported operators in Kotlin/Groovy files when they use template string escape syntax `$'{'$'}'` (e.g., `$'{'$'}'graphLookup`). This results in false negatives.

## Fix

Added a one-line normalization that replaces `$'{'$'}'` with `$` before scanning each line.

## How to reproduce

Create a file `test.kt`:

```kotlin
class TestRepository {
    fun findHierarchy(): List<Document> {
        val pipeline = """
            [{ "$'{'$'}'graphLookup": { "from": "categories", "startWith": "$'{'$'}'parentId" }}]
        """.trimIndent()
        return collection.aggregate(pipeline)
    }
}
```

**Before fix:**
```
$ python3 compat.py --version 8.0 --directory test-dir
No unsupported operators found.
```

**After fix:**
```
$ python3 compat.py --version 8.0 --directory test-dir
The following 1 unsupported operators were found:
  $graphLookup | found 1 time(s)
```