### PR TITLE
Add amazon-documentdb-python-client to new developer/ directory

### DIFF
--- a/developer/README.md
+++ b/developer/README.md
@@ -1,0 +1,5 @@
+# Amazon DocumentDB Developer Tools
+
+Libraries, SDKs, and utilities that help developers build applications on Amazon DocumentDB.
+
+* [amazon-documentdb-python-client](./amazon-documentdb-python-client) - Python wrapper for PyMongo that enforces DocumentDB best practices (connection management, retry with backoff, telemetry, replica-set awareness) with two lines of config.

--- a/developer/amazon-documentdb-python-client/.gitignore
+++ b/developer/amazon-documentdb-python-client/.gitignore
@@ -1,0 +1,11 @@
+.venv/
+__pycache__/
+*.pyc
+*.egg-info/
+.pytest_cache/
+dist/
+build/
+.DS_Store
+uv.lock
+*.pem
+.env

--- a/developer/amazon-documentdb-python-client/LICENSE
+++ b/developer/amazon-documentdb-python-client/LICENSE
@@ -1,0 +1,175 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/developer/amazon-documentdb-python-client/README.md
+++ b/developer/amazon-documentdb-python-client/README.md
@@ -1,0 +1,118 @@
+# amazon-documentdb-python-client
+
+Two lines of config. Every Amazon DocumentDB best practice, enforced automatically.
+
+####  Before
+```python
+
+from pymongo import MongoClient
+
+client = MongoClient(
+    "mongodb://user:pass@mycluster.docdb.amazonaws.com:27017",
+    tls=True,
+    tlsCAFile="/certs/global-bundle.pem",
+    # are these right? is anything missing?
+)
+db = client["mydb"]
+```
+
+#### After
+
+```python
+
+import docdb
+from docdb.secrets import config_from_secret
+
+docdb.init(config_from_secret("prod/myapp/docdb", app_name="my-service"))
+
+db = docdb.get_client().db("mydb")
+# replicaSet, directConnection, retryWrites, pool sizing, TLS — handled
+
+```
+
+|  | Without this library | With this library |
+| --- | --- | --- |
+| Replica set mode | Easy to forget | Always on |
+| directConnection | Wrong default breaks failover | Enforced off |
+| retry[Reads, Writes] | Guaranteed once | Built-in exponential retry w/ backoff |
+| Client-per-request | Silent pool exhaustion | Singleton enforced |
+| Cursor leaks | No guardrail | managed_cursor context manager |
+| Troubleshooting | Queries are anonymous | app_name wired through |
+
+---
+
+## Prerequisites
+
+- Python >= 3.10
+- An [Amazon DocumentDB](https://docs.aws.amazon.com/documentdb/latest/developerguide/what-is.html) cluster
+- Network connectivity to the cluster (VPC, security groups, [SSH tunnel](https://docs.aws.amazon.com/documentdb/latest/developerguide/connect-from-outside-a-vpc.html), etc.)
+- The [Amazon RDS TLS CA bundle](https://docs.aws.amazon.com/documentdb/latest/developerguide/ca_cert_rotation.html):
+
+  ```bash
+  wget https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
+  ```
+
+---
+
+## Install
+
+```bash
+pip install .
+```
+
+With optional extras:
+
+```bash
+pip install ".[secrets]"      # AWS Secrets Manager support (requires boto3)
+pip install ".[cloudwatch]"   # CloudWatch telemetry backend (requires boto3)
+pip install ".[iam]"          # IAM authentication (requires pymongo[aws])
+```
+
+---
+
+## Quickstart
+
+**With explicit config:**
+
+```python
+import docdb
+from docdb import DocumentDBConfig
+
+docdb.init(DocumentDBConfig(
+    host="mycluster.cluster-abc123.us-east-1.docdb.amazonaws.com",
+    username="appuser",
+    password="changeme",
+    tls_ca_file="global-bundle.pem",
+    app_name="my-service",
+))
+
+db = docdb.get_client().db("mydb")
+db.orders.find_one({"_id": order_id})
+```
+
+**With Secrets Manager (production):**
+
+Requires `pip install ".[secrets]"`. The secret must contain `host`, `username`, and `password` as JSON fields. See [src/docdb/secrets.py](src/docdb/secrets.py) for supported secret formats.
+
+```python
+import docdb
+from docdb.secrets import config_from_secret
+
+docdb.init(config_from_secret("prod/myapp/docdb", region="us-east-1", app_name="my-service"))
+
+db = docdb.get_client().db("mydb")
+db.orders.find_one({"_id": order_id})
+```
+
+Flask, FastAPI, Lambda patterns in [examples/](examples/).
+
+---
+
+## Go deeper
+
+- [Full overview](docs/overview.md) — architecture, enforced defaults, plugin design, project structure
+- [Connection tracker](docs/connection_tracker.md) — failover behavior
+- [IAM authentication](docs/iam-auth.md) — password-less auth with IAM roles
+- [Plugin system](docs/plugins.md) — telemetry, retry, custom middleware
+- [Telemetry plugin](docs/telemetry.md) — metrics, heartbeats, tuning
+- [Retry plugin](docs/retry.md) — backoff, idempotent writes, transactions

--- a/developer/amazon-documentdb-python-client/docs/connection_tracker.md
+++ b/developer/amazon-documentdb-python-client/docs/connection_tracker.md
@@ -1,0 +1,95 @@
+# Connection Tracker
+
+## Overview
+
+The connection tracker monitors open connections per host and forcibly closes all connections to a host when it is removed from the topology (failover, scale-in, instance resize). Without it, stale connections can linger until `server_selection_timeout_ms` expires (30s default), causing delays during failover recovery.
+
+This is always active and enforced at the library level.
+
+---
+
+## Quickstart
+
+The connection tracker is built into every `DocumentDBClient` instance automatically.
+
+```python
+# Inspect connection state at any time:
+client = docdb.get_client()
+print(client.connections.total_connections)  # total open TCP connections
+print(client.connections.hosts)              # {("host1", 27017): 3, ("host2", 27017): 2}
+```
+
+---
+
+## Behavior
+
+Two PyMongo monitoring listeners fire automatically in the background:
+
+```text
+PyMongo internal events (automatic, background)
+    │
+    ├─ ConnectionCreatedEvent("host1:27017")
+    │     └─ tracker: connections["host1:27017"] += 1
+    │
+    ├─ ConnectionClosedEvent("host1:27017")
+    │     └─ tracker: connections["host1:27017"] -= 1
+    │
+    └─ TopologyDescriptionChangedEvent
+          prev: {host1, host2}  →  new: {host2}
+              └─ tracker: host1 removed → reset_server("host1:27017")
+                  └─ PyMongo closes all pooled connections to host1
+```
+
+The tracker does nothing visible when all instances are healthy. It silently maintains counters. You can inspect it via `client.connections.hosts` for dashboards, but it has no side effects during normal operation.
+
+#### Failover
+
+Without the tracker, stale connections wait 30s to time out. With the tracker, they're cleared the instant PyMongo's heartbeat detects the topology change (~10s boundary). Your app recovers in ~10s instead of ~40s.
+
+```text
+00:00  - host1 (primary) crashes
+       -- (5 pooled connections to host1 are now stale)
+
+00:10  - PyMongo heartbeat detects host1 is gone
+       - TopologyDescriptionChangedEvent: host1 removed
+
+       - ConnectionTracker.server_removed("host1:27017"):
+         -- logs: "host1:27017 removed from topology, closing 5 connection(s)"
+         -- calls reset_server → all 5 connections closed immediately
+         -- emits: docdb.tracker.pool_reset = 5
+
+       - Next query:
+         -- Server selection picks host2 (new primary)
+         -- Fresh connection opened
+         -- Query succeeds immediately — no 30s wait
+```
+
+#### Brief network blip
+
+The tracker does nothing during transient network issues. If hosts remain in the topology (both heartbeats succeed when the network recovers), no pool reset occurs. PyMongo handles individual dead sockets internally.
+
+#### Extended outage (>30s)
+
+If a host fails heartbeats long enough for PyMongo to remove it from the topology, the tracker clears its connections. When the host recovers and rejoins, PyMongo opens fresh connections on demand.
+
+#### Session state after connection switches
+
+When the tracker clears a pool and PyMongo opens new connections to a different host, no session state is lost. Parameters like read preference are properties of your Python objects (`Database`, `Collection`); they are sent per-operation in the wire protocol and don't live on the TCP connection. Amazon DocumentDB also maintains server-side session state across the cluster, so any active `ClientSession` continues seamlessly on the new connection.
+
+#### Metrics
+
+| Metric | When |
+| --- | --- |
+| `docdb.tracker.pool_reset` | Host removed from topology (value = number of connections cleared) |
+
+---
+
+## FAQ
+
+### Does it interfere with normal connection pool management?
+
+No. It only acts on topology changes (host removal). PyMongo's built-in pool management (idle timeout, max pool size) continues to operate independently.
+
+### What about multi-threading?
+
+All counter operations are protected by a `threading.Lock`. The tracker is safe for concurrent access from multiple threads sharing the same `DocumentDBClient`.

--- a/developer/amazon-documentdb-python-client/docs/iam-auth.md
+++ b/developer/amazon-documentdb-python-client/docs/iam-auth.md
@@ -1,0 +1,140 @@
+# IAM Authentication
+
+## Overview
+
+The wrapper also supports Amazon DocumentDB's ability to use password-less authentication through [AWS IAM](https://docs.aws.amazon.com/IAM/latest/UserGuide/id.html) users and roles. The driver retrieves temporary credentials from [AWS STS](https://docs.aws.amazon.com/STS/latest/APIReference/Welcome.html) and uses them to authenticate.
+
+---
+
+## Quickstart
+
+```python
+from docdb import DocumentDBConfig
+
+config = DocumentDBConfig(
+    host="mycluster.cluster-abc123.us-east-1.docdb.amazonaws.com",
+    app_name="my-service",
+    iam_auth=True,
+)
+```
+
+If your compute environment has an IAM role attached (EC2 instance profile, Lambda execution role, EKS pod identity, Fargate task role), the driver picks up credentials automatically from environment variables or instance metadata.
+
+---
+
+## Configuration
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `iam_auth` | `False` | When `True`, uses `authMechanism="MONGODB-AWS"` instead of username/password |
+
+No other configuration is needed. Credentials are sourced from the environment automatically.
+
+### Prerequisites
+
+| Requirement | Details |
+| --- | --- |
+| Amazon DocumentDB version | 5.0+ (instance-based clusters only) |
+| Python dependency | `pip install 'pymongo[aws]'` |
+| IAM user restriction | Cannot be the cluster's primary user |
+| TLS | Must be enabled |
+
+### IAM policy
+
+The IAM role or user needs permission to connect:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "rds-db:connect",
+            "Resource": "arn:aws:rds-db:us-east-1:123456789012:dbuser:cluster-abc123/*"
+        }
+    ]
+}
+```
+
+Replace the `Resource` ARN with your cluster's resource ID.
+
+### Creating a database user
+
+You must create a database user in Amazon DocumentDB that maps to the IAM identity that will connect.
+
+**Option 1: IAM role** (Lambda, ECS, EKS, EC2 instance profile)
+
+```javascript
+use $external;
+db.createUser(
+    {
+        user: "arn:aws:iam::123456789123:role/iamrole",
+        mechanisms: ["MONGODB-AWS"],
+        roles: [ { role: "readWrite", db: "readWriteDB" } ]
+    }
+);
+```
+
+Any compute instance that assumes this role can authenticate without credentials in the application code.
+
+**Option 2: IAM user** (developer workstations, CI/CD)
+
+```javascript
+use $external;
+db.createUser(
+    {
+        user: "arn:aws:iam::123456789123:user/iamuser",
+        mechanisms: ["MONGODB-AWS"],
+        roles: [ { role: "readWrite", db: "readWriteDB" } ]
+    }
+);
+```
+
+The IAM user's access keys must be available as environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) or in `~/.aws/credentials`. You can review the full details in [Authentication using IAM identity](https://docs.aws.amazon.com/documentdb/latest/developerguide/iam-identity-auth.html).
+
+---
+
+## Behavior
+
+### How authentication works
+
+1. PyMongo (with the `pymongo[aws]` extra) detects `authMechanism="MONGODB-AWS"`
+2. It retrieves temporary credentials from one of:
+   - Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`)
+   - EC2 instance metadata (IMDS)
+   - ECS task role endpoint
+   - EKS pod identity
+3. It sends an STS-signed authentication request to Amazon DocumentDB
+4. Amazon DocumentDB validates the signature with STS and establishes the session
+5. The connection is now authenticated and credentials are not stored or sent again
+
+Credentials are only used during connection establishment. Once authenticated, the connection remains valid even if the temporary credentials expire or rotate. No token caching or refresh logic is needed as the connection pool is effectively the cache. New STS calls only happen when PyMongo opens a genuinely new connection (pool growth or replacement), which the wrapper's pool settings (`min_pool_size=5`, `max_idle_time_ms=10000`) already minimize.
+
+### STS throttling
+
+IAM authentication calls AWS STS for every new connection. At very high connection rates (hundreds of new connections per second), this can hit STS throttling limits.
+
+In practice, the wrapper's defaults already prevent this: `min_pool_size=5` keeps connections warm, `max_idle_time_ms=10000` avoids unnecessary churn, and the singleton pattern prevents per-request client creation. New STS calls only happen when the pool genuinely needs to grow.
+
+If you're running an extremely high-throughput service and still see STS throttling, increase `min_pool_size` to keep more connections warm and reduce the rate of new connection establishment.
+
+## FAQ
+
+### When should I use IAM auth vs. Secrets Manager?
+
+| Scenario | Use | Why |
+| --- | --- | --- |
+| Lambda, ECS, EKS, Fargate | IAM role | Credentials are automatic |
+| EC2 with instance profile | IAM role | Credentials are automatic (from IMDS) |
+| CI/CD pipeline | IAM user | Pipeline has static credentials |
+| Local development | IAM user | Access keys in `~/.aws/credentials` |
+| Pre-5.0 clusters | Secrets Manager | IAM auth requires 5.0+ |
+| Primary user | Secrets Manager | IAM auth cannot be used with the primary user |
+
+### Do I need to rotate credentials?
+
+No. STS tokens are short-lived by design and only used at connection time. Once a connection is established, it stays authenticated regardless of token expiry. There's nothing to rotate at the application level.
+
+### What happens during failover?
+
+The connection tracker clears stale connections. When PyMongo opens new connections to the new primary, it calls STS again to authenticate the new connections.

--- a/developer/amazon-documentdb-python-client/docs/overview.md
+++ b/developer/amazon-documentdb-python-client/docs/overview.md
@@ -1,0 +1,170 @@
+# Overview
+
+## Why this exists
+
+Document databases are compelling because they match how developers think: 
+
+- store JSON
+- no schema
+- iterate fast
+
+MongoDB makes this even easier: no authentication required locally, no setup ceremony, just connect and start inserting. Especially with GenAI coding tools like Claude, you can go from zero to a working app in minutes.
+
+But the simplicity that makes development fast masks the architectural decisions you'll need at scale. You build locally with no auth, no TLS, no connection pooling, no replica awareness and it works. So you promote to test, then to production, and it still works...until it doesn't.
+
+Maybe you discover that your connection pool is exhausting the cluster because every Lambda invocation opens a new client. Or a primary failover takes down your service because the driver didn't know it was in a replica set. These aren't edge cases, they're the natural consequence of patterns that work perfectly at development scale but fail at production scale.
+
+By the time you discover them, you're patching a production environment live on a Friday night.
+
+**This library puts you in the right position from the start.** 
+
+Dev to test to prod is seamless because the same best practices are enforced from your first line of code. You're well-architected before you even begin without needing to know the details.
+
+#### What is enforced automatically
+
+| Parameter | Value | Why |
+| --- | --- | --- |
+| `replicaSet` | `rs0` | Required for replica set routing and failover. |
+| `directConnection` | `False` | Guards against connecting to a single node. |
+| `retryWrites` | `False` | PyMongo defaults this to `True`. |
+| Connection tracker | Always active | Forcibly closes connections to hosts removed from topology. |
+
+#### Defaults (can be overridden via `DocumentDBConfig`)
+
+| Parameter | Default | Why |
+| --- | --- | --- |
+| `tls` | `True` | Enabled by default on Amazon DocumentDB clusters. |
+| `read_preference` | `secondaryPreferred` | Routes reads to replicas, reducing primary load. |
+| `max_pool_size` | `100` | Sized for typical workloads. |
+| `min_pool_size` | `5` | Keeps connections warm, reduces cold-start latency. |
+| `max_idle_time_ms` | `10000` | Closes idle connections to prevent stale accumulation. |
+| `server_selection_timeout_ms` | `30000` | Configured to handle a failover (~30 seconds). |
+| `connect_timeout_ms` | `10000` | Timeout for new TCP connections. |
+
+---
+
+## How it works — two layers
+
+### Layer 1 - Safe defaults
+
+Under the hood, the wrapper enforces `replicaSet=rs0`, `directConnection=False`, `retryWrites=False`, proper TLS, connection pooling, and other best practices for Amazon DocumentDB. Your code reads exactly like standard PyMongo.
+
+```python
+import docdb
+from docdb import DocumentDBConfig
+
+config = DocumentDBConfig(
+    host="mycluster.cluster-abc123.us-east-1.docdb.amazonaws.com",
+    username="appuser",
+    password="changeme",
+    app_name="my-service",
+)
+docdb.init(config)
+
+client = docdb.get_client()
+db = client.db("mydb")
+db.orders.find_one({"_id": order_id})
+```
+
+### Layer 2 - Plugin chain
+
+When you need cross-cutting behavior such as logging, retries, telemetry, you can add plugins that transparently intercept operations:
+
+```python
+from docdb import DocumentDBConfig, PluginConfig
+from docdb.telemetry import TelemetryConfig, MetricsBackend
+
+config = DocumentDBConfig(
+    host="mycluster.cluster-abc123.us-east-1.docdb.amazonaws.com",
+    app_name="order-service",
+    telemetry=TelemetryConfig(enabled=True, metrics_backend=MetricsBackend.CLOUDWATCH),
+    plugins=[
+        PluginConfig("retry"),
+    ],
+)
+```
+
+Your queries stay the same (`db.orders.find_one(...)`) but now every operation automatically gets telemetry and retry logic without touching your business code.
+
+---
+
+## Plugin design
+
+Without plugins, retry logic is scattered across every file that talks to the database:
+
+```python
+for attempt in range(3):
+    try:
+        result = db.orders.find_one({"_id": oid})
+        break
+    except (AutoReconnect, ConnectionFailure):
+        if attempt == 2:
+            raise
+        time.sleep(0.1 * 2**attempt)
+```
+
+Multiply that by every query in your service. Now add timing. Now add audit logging. Each concern wraps the others, and the nesting gets unmanageable.
+
+With the retry plugin, all of that goes away. The retry logic lives in the plugin, configured once:
+
+```python
+plugins=[PluginConfig("retry")]
+```
+
+...and you just run your code like normal
+
+```python
+db.orders.find_one({"_id": oid})
+```
+
+The modular design allows you to add your own plugins (see [docs/plugins.md](plugins.md)).
+
+---
+
+## Performance
+
+The wrapper is designed for zero measurable overhead. All Python-side work (proxy dispatch, plugin chain, telemetry recording, connection tracking) operates in the single-digit microsecond range which disappears into the noise of a typical network round-trip to Amazon DocumentDB (1–50ms depending on your VPC topology).
+
+---
+
+## Compatibility
+
+- Python 3.10+
+- PyMongo 4.6+ (tested against 4.x; pinned below 5.0)
+- The wrapper does not introduce any incompatibility beyond what already exists between PyMongo and Amazon DocumentDB
+
+---
+
+## Project structure
+
+```text
+├── pyproject.toml                          # Package config, dependencies, extras
+├── src/docdb/
+│   ├── __init__.py                         # Public API (init, get_client, shutdown)
+│   ├── client.py                           # DocumentDBClient singleton, MongoClient construction
+│   ├── config.py                           # DocumentDBConfig dataclass
+│   ├── connection_tracker.py               # Always-on connection tracking + pool cleanup
+│   ├── cursor.py                           # managed_cursor, find_all helpers
+│   ├── secrets.py                          # AWS Secrets Manager config loader
+│   ├── plugins/
+│   │   ├── __init__.py                     # Plugin public API exports
+│   │   ├── base.py                         # ConnectionPlugin ABC, OperationContext
+│   │   ├── chain.py                        # PluginChainBuilder, PluginPipeline
+│   │   ├── proxy.py                        # PluginAwareDatabase, PluginAwareCollection
+│   │   ├── registry.py                     # Plugin registry (register_plugin)
+│   │   └── builtin/
+│   │       ├── __init__.py                 # Built-in plugin registration
+│   │       ├── default_plugin.py           # Terminal plugin (calls real PyMongo)
+│   │       ├── retry_plugin.py             # Retry with exponential backoff
+│   │       └── telemetry_plugin.py         # Operation-level spans and metrics
+│   └── telemetry/
+│       ├── __init__.py                     # Telemetry public API
+│       ├── backend.py                      # TelemetryBackend ABC, NoOpBackend
+│       ├── cloudwatch_backend.py           # CloudWatch metrics publisher
+│       ├── config.py                       # TelemetryConfig, build_backend
+│       ├── listeners.py                    # PyMongo event listeners
+│       ├── log_backend.py                  # Structured logging backend
+│       └── types.py                        # Metric names, enums, SpanContext
+├── docs/                                   # Detailed documentation
+└── examples/                               # Runnable demos and integration patterns
+```

--- a/developer/amazon-documentdb-python-client/docs/plugins.md
+++ b/developer/amazon-documentdb-python-client/docs/plugins.md
@@ -1,0 +1,162 @@
+# Plugin System
+
+## Overview
+
+The plugin system intercepts collection operations (find, insert, update, delete, aggregate) and routes them through a composable chain of middleware without changing your application code.
+
+---
+
+## Quickstart
+
+```python
+from docdb import DocumentDBConfig, PluginConfig
+
+config = DocumentDBConfig(
+    host="mycluster.cluster-abc123.us-east-1.docdb.amazonaws.com",
+    app_name="my-service",
+    plugins=[
+        PluginConfig("retry"),
+    ],
+)
+```
+
+---
+
+## Configuration
+
+### Built-in plugins
+
+| Plugin | Code | Weight | What it does |
+| --- | --- | --- | --- |
+| [TelemetryPlugin](telemetry.md) | `"telemetry"` | 100 | Operation-level spans and duration metrics (auto-injected when telemetry is enabled) |
+| [RetryPlugin](retry.md) | `"retry"` | 500 | Retries failed operations with exponential backoff and jitter |
+| DefaultPlugin | `"_default"` | 1000 | Calls the PyMongo method directly (always last) |
+
+### Method subscription
+
+Plugins can intercept all operations or declare exactly what they care about:
+
+```python
+def subscribed_methods(self):
+    return frozenset({"find", "find_one", "aggregate"})  # e.g. reads only
+```
+
+Operations not in your set bypass your plugin entirely so there is no overhead, not even a function call.
+
+### What's intercepted
+
+The 16 most common collection operations go through the plugin chain:
+
+`find`, `find_one`, `insert_one`, `insert_many`, `update_one`, `update_many`, `replace_one`, `delete_one`, `delete_many`, `aggregate`, `bulk_write`, `find_one_and_update`, `find_one_and_replace`, `find_one_and_delete`, `count_documents`, `distinct`
+
+Administrative methods like `create_index`, `list_indexes`, `rename` pass directly to PyMongo.
+
+---
+
+## Architecture
+
+```text
+db.orders.find_one({"_id": "123"})
+         │
+         ▼
+┌────────────────────────────────────────────┐
+│  Plugin Chain (sorted by weight)           │
+│                                            │
+│  TelemetryPlugin                           │  ← measures total time
+│      → next ─┐                             │
+│              ▼                             │
+│  RetryPlugin                               │  ← catches errors, retries
+│      → next ─┐                             │
+│              ▼                             │
+│  DefaultPlugin                             │  ← calls PyMongo
+│      → collection.find_one({"_id": "123"}) │
+└────────────────────────────────────────────┘
+         │
+         ▼
+       Result
+```
+
+| Property | What it means | Why it matters |
+| --- | --- | --- |
+| **Weight-based ordering** | Lower weight = runs first | Add your plugin at any weight and it slots in automatically. |
+| **Method subscription** | Each plugin declares what it intercepts | A retry plugin subscribes to reads only. Write operations skip it entirely with zero overhead. |
+| **Pre-built dispatch** | Chain is assembled once at startup | Per-query cost is a single dict lookup + closure call. No iteration or filtering on the hot path. |
+| **Transparent proxy** | `client.db()` returns a proxy that looks identical to `pymongo.Database` | Your code, tests, and IDE autocomplete all work unchanged. |
+
+### OperationContext
+
+Every intercepted call receives an `OperationContext`:
+
+```python
+@dataclass
+class OperationContext:
+    method: str                 # e.g. "find_one", "insert_one"
+    collection_name: str        # e.g. "orders"
+    database_name: str          # e.g. "shop"
+    args: tuple                 # positional args to the PyMongo method
+    kwargs: dict[str, Any]      # keyword args
+    attributes: dict[str, Any]  # inter-plugin communication
+```
+
+`attributes` is a free-form dict for plugins to communicate. The key `_pymongo_collection` holds the PyMongo Collection.
+
+| Capability | How |
+| --- | --- |
+| **Observe** | Record timing, log operations, emit metrics |
+| **Modify** | Change arguments before they reach PyMongo, transform results after |
+| **Retry** | Catch errors from `next_fn`, re-invoke it with backoff |
+| **Short-circuit** | Return a cached result without calling `next_fn` at all |
+| **Communicate** | Set `ctx.attributes["key"]` for downstream plugins to read |
+
+### Writing a custom plugin
+
+```python
+from docdb import BaseConnectionPlugin, PluginConfig, register_plugin
+
+class AuditPlugin(BaseConnectionPlugin):
+    """Logs every database operation."""
+
+    @property
+    def plugin_code(self):
+        return "audit"
+
+    @property
+    def weight(self):
+        return 150  # runs after telemetry (100), before retry (500)
+
+    def subscribed_methods(self):
+        return frozenset({"*"})  # all operations
+
+    def execute(self, ctx, next_fn):
+        print(f"[audit] {ctx.collection_name}.{ctx.method}()")
+        result = next_fn(ctx)  # call the next plugin in chain
+        print(f"[audit] completed")
+        return result
+
+# Register so it can be referenced by name in config
+register_plugin("audit", lambda **opts: AuditPlugin())
+
+# Enable it
+config = DocumentDBConfig(
+    host="...",
+    plugins=[PluginConfig("audit")],
+)
+```
+
+Plugins that hold resources should implement a `close()` method. It will be called automatically when `docdb.shutdown()` is invoked.
+
+---
+
+## FAQ
+
+### Do plugins add latency to every query?
+
+The per-query overhead is a dict lookup and a closure call, an impact of nanoseconds. The chain is pre-built at startup, not assembled per-operation. If a plugin doesn't subscribe to a method, it's not in that method's chain.
+
+### Can I use multiple plugins together?
+
+Yes. The weight system handles ordering automatically. You don't need to wire them manually. Each plugin is independent and communicates only through `ctx.attributes` if needed.
+
+### What if I want to intercept administrative operations (create_index, etc.)?
+
+Those bypass the proxy for performance reasons. Use PyMongo's `event_listeners` directly via `extra_options` if you need to observe them, or access the raw client via `client.raw`.

--- a/developer/amazon-documentdb-python-client/docs/retry.md
+++ b/developer/amazon-documentdb-python-client/docs/retry.md
@@ -1,0 +1,124 @@
+# Retry Plugin
+
+## Overview
+
+Without retries, transient network errors (connection resets during failover, brief DNS resolution failures, momentary overloads) surface directly to your application. The retry plugin handles this automatically with exponential backoff and jitter.
+
+---
+
+## Quickstart
+
+```python
+from docdb import DocumentDBConfig, PluginConfig
+
+config = DocumentDBConfig(
+    host="mycluster.cluster-abc123.us-east-1.docdb.amazonaws.com",
+    app_name="order-service",
+    plugins=[PluginConfig("retry")],
+)
+```
+
+---
+
+## Configuration
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `max_attempts` | 3 | Total attempts (1 initial + 2 retries) |
+| `base_delay_ms` | 100 | Base delay for exponential backoff |
+| `max_delay_ms` | 5000 | Maximum delay cap |
+| `retry_methods` | reads only | Which methods to retry. Add write methods only if they're idempotent. |
+
+```python
+PluginConfig("retry", options={
+    "max_attempts": 5,
+    "base_delay_ms": 200,
+    "max_delay_ms": 10000,
+    "retry_methods": ["find", "find_one", "insert_one", "update_one"],
+})
+```
+
+Default read methods retried: `find`, `find_one`, `count_documents`, `distinct`, `aggregate`.
+
+---
+
+## Behavior
+
+Only PyMongo transient errors trigger a retry:
+
+- `AutoReconnect` — connection dropped mid-operation
+- `ConnectionFailure` — cannot establish connection
+- `NetworkTimeout` — operation timed out at network level
+- `ServerSelectionTimeoutError` — no suitable server found within timeout
+
+Application errors (`DuplicateKeyError`, `ValidationError`, etc.) propagate immediately.
+
+### Retries reads only by default
+
+Retrying writes is unsafe unless your writes are idempotent. For example, your application calls `insert_one({"customer_id": auto_generated, "amount_owed": 100})`. The document is written successfully, but the acknowledgment is lost due to a network error. The retry would then insert a duplicate document for the specified `customer_id`.
+
+### Backoff strategy
+
+Full jitter (per [AWS Builders' Library](https://aws.amazon.com/builders-library/timeouts-retries-and-backoff-with-jitter/)):
+
+```text
+delay = random(0, min(base_delay_ms * 2^attempt, max_delay_ms))
+```
+
+Each retry picks a random delay between 0 and the exponential ceiling. This prevents "thundering herds" when multiple clients fail simultaneously during failover.
+
+| Attempt | Max possible delay |
+| --- | --- |
+| 1st retry | 0–100ms |
+| 2nd retry | 0–200ms |
+| 3rd retry | 0–400ms |
+| 4th retry | 0–800ms |
+| 5th retry | 0–1600ms |
+| 6th+ retry | 0–5000ms (capped) |
+
+### Retrying writes safely
+
+Idempotent (safe to retry):
+
+- `update_one` with `$set` — setting a field to the same value twice is harmless
+- `insert_one` with a deterministic `_id` — duplicate insert fails with `DuplicateKeyError` (which is not a retryable error, so it propagates immediately)
+- `delete_one` — deleting an already-deleted document is a no-op
+
+Not idempotent (do not retry):
+
+- `insert_one` with auto-generated `_id` — retry creates a duplicate
+- `update_one` with `$inc` — retry increments twice
+- `insert_many` without explicit `_id` values — partial retry duplicates some documents
+
+For non-idempotent writes, use application-level deduplication keys rather than automatic retries.
+
+### Interaction with other plugins
+
+The retry plugin runs inside the telemetry plugin because it has a higher weight. Telemetry measures total time including retries, giving you visibility into the full user-side latency.
+
+### Session state across retries
+
+When a retry connects to a different host (e.g., after failover to a new primary), your driver parameters (like read preference) are preserved automatically. These settings are sent per-operation in the wire protocol since they're properties of your Python objects (`Database`, `Collection`), not of the physical TCP connection. Amazon DocumentDB also maintains server-side session state across the cluster, so `ClientSession` continuity is preserved even when the underlying connection changes. A retry to a new host behaves identically to the original attempt and no session state is lost.
+
+### Metrics emitted
+
+| Metric | When |
+| --- | --- |
+| `docdb.retry.triggered` | Each retry attempt (transient error caught) |
+| `docdb.retry.exhausted` | All attempts failed, error propagated to application |
+
+---
+
+## FAQ
+
+### Will retries hide real failures from me?
+
+No. If all retry attempts fail, the original error propagates to your application code. The `docdb.retry.exhausted` metric fires so you see it in CloudWatch. Retries only mask *transient* issues that resolve quickly.
+
+### Should I retry writes?
+
+Only if they're idempotent. If you use deterministic `_id` values or `$set` operations, it's safe. If you use `$inc` or auto-generated IDs, don't.
+
+### What if the retry succeeds but takes too long?
+
+The telemetry plugin wraps the retry plugin, so your `docdb.commands.duration_ms` metric shows the full latency including retry delays. You'll see the spike in your dashboard.

--- a/developer/amazon-documentdb-python-client/docs/telemetry.md
+++ b/developer/amazon-documentdb-python-client/docs/telemetry.md
@@ -1,0 +1,269 @@
+# Telemetry Plugin
+
+## Overview
+
+The telemetry system adds automatic observability to every Amazon DocumentDB operation without changing application code. When enabled, it hooks into PyMongo's built-in monitoring system and translates raw events into structured metrics and traces.
+
+```terminal
+Your App Code (find, insert, etc.)
+        │
+        ▼
+┌─────────────────────────────────┐
+│  PyMongo MongoClient            │  ← already emits internal events
+│  (CommandStarted/Succeeded/     │
+│   Failed, Heartbeat, Topology,  │
+│   Pool events)                  │
+└────────────┬────────────────────┘
+             │
+             ▼
+┌─────────────────────────────────┐
+│  Telemetry listeners            │  ← translate events into metrics/spans
+│  (CommandListener, Heartbeat,   │
+│   Topology, Pool)               │
+└────────────┬────────────────────┘
+             │
+             ▼
+┌─────────────────────────────────┐
+│  Backend (LOG or CloudWatch)    │  ← decides where the data goes
+└─────────────────────────────────┘
+```
+
+---
+
+## Quickstart
+
+```python
+from docdb import DocumentDBConfig
+from docdb.telemetry import TelemetryConfig, MetricsBackend
+
+# Log to stdout
+config = DocumentDBConfig(
+    host="your-cluster.docdb.amazonaws.com",
+    app_name="my-service",
+    telemetry=TelemetryConfig(enabled=True),
+)
+
+# Publish to CloudWatch
+config = DocumentDBConfig(
+    host="your-cluster.docdb.amazonaws.com",
+    app_name="my-service",
+    telemetry=TelemetryConfig(
+        enabled=True,
+        metrics_backend=MetricsBackend.CLOUDWATCH,
+        default_dimensions={"environment": "prod"},
+    ),
+)
+```
+
+Example LOG output:
+
+```bash
+10:09:27 docdb.telemetry | [metric] docdb.commands.total += 1
+10:09:27 docdb.telemetry | [span:start] docdb.command.insert
+10:09:27 docdb.telemetry | [span:end] docdb.command.insert duration=2.1ms
+10:09:27 docdb.telemetry | [metric] docdb.connections.opened += 1
+10:09:37 docdb.telemetry | [metric] docdb.heartbeat.duration_ms: 0.8
+```
+
+---
+
+## Configuration
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `enabled` | `False` | Main switch. When False, all telemetry is disabled. |
+| `metrics_backend` | `MetricsBackend.LOG` | Where metrics go - `LOG` (stdout) or `CLOUDWATCH` |
+| `cloudwatch_namespace` | Auto-derived | CloudWatch namespace (default `DocumentDB/{cluster-id}` from host) |
+| `cloudwatch_flush_interval_seconds` | `60` | How often buffered CloudWatch metrics are flushed |
+| `cloudwatch_client` | `None` | Optional pre-configured boto3 CloudWatch client |
+| `default_dimensions` | `{}` | Dimensions added to every metric (e.g., `{"environment": "prod"}`) |
+| `enabled_listeners` | `{"command", "heartbeat", "topology", "pool"}` | Which PyMongo listeners are active |
+| `emit_spans` | `True` | Whether to emit span start/end events |
+| `log_level` | `DEBUG` | Log level for the LOG backend |
+
+Auto-derived dimensions (always present):
+
+- `service` — from `app_name`
+- `cluster` — from the host endpoint
+
+### CloudWatch prerequisites
+
+| Requirement | Details |
+| --- | --- |
+| IAM | `cloudwatch:PutMetricData` permission on your app's role |
+| pip | `pip install 'amazon-documentdb-python-client[cloudwatch]'` |
+| Region | Via `AWS_DEFAULT_REGION`, instance metadata, or explicit client |
+| CloudWatch console | Namespaces and metrics auto-create on first write |
+
+### Bring your own boto3 client
+
+```python
+import boto3
+
+cw_client = boto3.client("cloudwatch", region_name="us-west-2")
+
+telemetry=TelemetryConfig(
+    enabled=True,
+    metrics_backend=MetricsBackend.CLOUDWATCH,
+    cloudwatch_client=cw_client,
+)
+```
+
+---
+
+## Behavior
+
+### Metrics emitted
+
+| Metric | Source | When it fires |
+| --- | --- | --- |
+| `docdb.commands.total` | Telemetry listener | Every command executed |
+| `docdb.commands.failed` | Telemetry listener | Command returns an error |
+| `docdb.commands.duration_ms` | Telemetry listener | Command completes (success or failure) |
+| `docdb.heartbeat.duration_ms` | Telemetry listener | Every heartbeat probe (~10s per node) |
+| `docdb.heartbeat.failed` | Telemetry listener | Heartbeat probe fails |
+| `docdb.connections.opened` | Telemetry listener | New TCP connection created |
+| `docdb.connections.closed` | Telemetry listener | Connection closed (with reason dimension) |
+| `docdb.topology.changed` | Telemetry listener | Server added or removed from replica set |
+| `docdb.tracker.pool_reset` | Connection tracker | Host removed from topology, connections cleared |
+| `docdb.retry.triggered` | Retry plugin | Each retry attempt on a transient error |
+| `docdb.retry.exhausted` | Retry plugin | All retry attempts failed |
+
+### CloudWatch dimension groups
+
+Metrics appear under namespace `DocumentDB/{cluster-id}`:
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│ command, cluster, environment, service                      │
+│   docdb.commands.total                                      │
+│   docdb.commands.duration_ms                                │
+│   docdb.commands.failed                                     │
+├─────────────────────────────────────────────────────────────┤
+│ cluster, environment, service                               │
+│   docdb.connections.opened                                  │
+│   docdb.heartbeat.duration_ms                               │
+│   docdb.heartbeat.failed                                    │
+│   docdb.topology.changed                                    │
+├─────────────────────────────────────────────────────────────┤
+│ cluster, environment, reason, service                       │
+│   docdb.connections.closed                                  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Heartbeats
+
+PyMongo runs a background thread that pings every server in the replica set every 10 seconds. This is how the driver discovers which nodes are alive, which is primary, and which are secondaries.
+
+```text
+PyMongo background thread
+    │ every 10s, sends "hello" command to each node
+    │
+    ├─ Node responds → ServerHeartbeatSucceededEvent
+    │   └─ Plugin emits: docdb.heartbeat.duration_ms = 1.2
+    │
+    └─ Node doesn't respond → ServerHeartbeatFailedEvent
+        └─ Plugin emits: docdb.heartbeat.failed += 1
+                    docdb.heartbeat.duration_ms = 5000.0 (timeout value)
+```
+
+| Scenario | What happens | Metric pattern |
+| --- | --- | --- |
+| Primary failover | Old primary stops responding, new primary elected | Spike of `heartbeat.failed` for ~30s, then recovers |
+| Instance reboot | One instance goes offline temporarily | `heartbeat.failed` spikes for that instance's 10s-intervals until it's back |
+| Network partition | VPC routing issue between app and a replica | Sustained `heartbeat.failed` — triggers investigation |
+| Instance removed | Instance leaves replica set | Brief `heartbeat.failed` until PyMongo removes it from topology |
+
+Heartbeat failures show up in CloudWatch *before* your application queries fail. If you see `heartbeat.failed` spiking but `commands.failed` is flat, it means PyMongo is routing around the bad instance successfully. If both spike together, the cluster should be reviewed.
+
+### Failed commands
+
+Any command (find, insert, update, aggregate, etc.) that PyMongo reports as failed at the wire protocol level. This is *not* "zero results found", it's an actual error response from the server or a network failure during the command.
+
+```text
+Your code: db.orders.insert_one({"_id": "..."})
+    │
+    PyMongo sends insert command to Amazon DocumentDB
+    │
+    Amazon DocumentDB returns error (e.g., duplicate key)
+    │
+    PyMongo fires CommandFailedEvent
+    │
+    Plugin emits:
+        docdb.commands.failed += 1       {command: "insert"}
+        docdb.commands.duration_ms = 3.2 {command: "insert"}
+```
+
+| Scenario | Error type | Example |
+| --- | --- | --- |
+| Duplicate key | `DuplicateKeyError` | Retry logic inserts the same `_id` twice |
+| Write to a secondary | `NotWritablePrimary` | App connects to reader endpoint and attempts a write |
+| Command timeout | `ExecutionTimeout` | Long-running aggregation exceeds `maxTimeMS` |
+| Auth failure | `AuthenticationFailed` | Credentials rotated but app not restarted |
+| Exceeding Amazon DocumentDB limits | `ExceededMemoryLimit` | Aggregation pipeline uses too much RAM |
+| Network error mid-command | `NetworkTimeout` | Connection drops after command sent but before response received |
+| Collection doesn't exist | `NamespaceNotFound` | Code references a dropped collection |
+
+**What it does NOT capture:**
+
+- A `find()` returning zero documents. This is a successful command with empty results.
+- Application-level validation errors (occur before the command is sent)
+- Slow queries - those succeed (tracked by `duration_ms` instead)
+
+### Failover scenario
+
+In CloudWatch, you'd see `heartbeat.failed` spike 15 seconds before `commands.failed`, giving you early warning that the cluster is degraded before users are impacted.
+
+```text
+Timeline:
+  00:00  Normal operation
+         heartbeat.failed = 0, commands.failed = 0
+
+  00:15  Primary instance starts failing
+         heartbeat.failed += 1 (every 10s probe fails)
+         heartbeat.duration_ms spikes to 5000ms (timeout)
+         commands.failed still 0 (PyMongo hasn't tried primary yet)
+
+  00:25  App sends a write → routed to old primary → fails
+         commands.failed += 1 {command: "insert"}
+         PyMongo triggers server selection, waits for new primary
+
+  00:30  New primary elected, heartbeat succeeds
+         heartbeat.failed drops to 0
+         heartbeat.duration_ms returns to ~1ms
+         commands resume succeeding
+
+  00:35  Fully recovered
+         commands.failed = 0, all metrics normal
+```
+
+### Batching
+
+The CloudWatch backend buffers metric data points and flushes them in batches of 20 (CloudWatch's `put_metric_data` limit per call).
+
+1. Each `record_metric()` call adds to an in-memory buffer
+2. If the buffer hits 20 items, it flushes immediately
+3. Otherwise a background thread flushes every `flush_interval_seconds`
+4. On `client.close()` / `docdb.shutdown()`, remaining metrics are flushed
+
+---
+
+## FAQ
+
+### When should I tune `enabled_listeners` or `emit_spans`?
+
+The defaults work for the vast majority of services. These options exist for high-throughput production services (10,000+ QPS) where have metric data or large log volumes you're not looking at. See the tuning guide below.
+
+### Dev → Test → Prod tuning guide
+
+| Stage | `enabled_listeners` | `emit_spans` | Why |
+| --- | --- | --- | --- |
+| Dev | all (default) | `True` (default) | See everything, learn the system |
+| Test | all (default) | `True` (default) | Validate metrics appear correctly in CloudWatch |
+| Prod (normal) | all (default) | `False` | Metrics to CloudWatch, no log noise |
+| Prod (high-throughput) | heartbeat, topology, pool | `False` | Infrastructure visibility only, minimal overhead |
+| Prod (incident investigation) | all | `True` | Temporarily re-enable everything to diagnose |
+
+### What's the overhead?
+
+Per-query cost is a dict lookup and a deque append. The background flush thread handles CloudWatch API calls.

--- a/developer/amazon-documentdb-python-client/examples/01_basic.py
+++ b/developer/amazon-documentdb-python-client/examples/01_basic.py
@@ -1,0 +1,39 @@
+"""
+Example 01 — Basic usage with explicit config
+
+Use this pattern in scripts or local development.
+"""
+
+import docdb
+from docdb import DocumentDBConfig, managed_cursor
+
+# Build config manually. In production, prefer secrets.config_from_secret().
+config = DocumentDBConfig(
+    host="mycluster.cluster-abc123.us-east-1.docdb.amazonaws.com",
+    username="appuser",
+    password="changeme",
+    app_name="example-script",  # shows up in slow query logs
+    tls_ca_file="/etc/ssl/certs/global-bundle.pem",
+)
+
+# Initialize once. This creates the connection pool.
+docdb.init(config)
+
+client = docdb.get_client()
+db = client.db("shop")
+
+# --- Simple find_one (cursor exhausted immediately and no managed_cursor needed)
+order = db.orders.find_one({"status": "pending"})
+print(order)
+
+# --- find() with limit — use managed_cursor to guarantee close()
+with managed_cursor(db.orders.find({"status": "pending"}).limit(10)) as cursor:
+    for doc in cursor:
+        print(doc["_id"])
+
+# --- Insert
+db.orders.insert_one({"item": "widget", "qty": 5, "status": "new"})
+
+# --- Health check
+if client.ping():
+    print("cluster is reachable")

--- a/developer/amazon-documentdb-python-client/examples/02_flask_app.py
+++ b/developer/amazon-documentdb-python-client/examples/02_flask_app.py
@@ -1,0 +1,51 @@
+"""
+Example 02 — Flask application
+
+The MongoClient must be initialized ONCE when the app starts, not per
+request. Creating a new client per request opens a new connection pool
+on every call and can exhaust Amazon DocumentDB's connection limit under any
+meaningful load.
+
+This example uses an app factory pattern with Flask.
+"""
+
+import atexit
+
+from flask import Flask, jsonify
+import docdb
+from docdb.secrets import config_from_secret
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+
+    # Initialize at startup. The connection pool is created here (once).
+    config = config_from_secret(
+        "prod/shop/docdb",
+        region="us-east-1",
+        app_name="shop-api",          # attributes slow queries in profiler
+        max_pool_size=50,             # tune to instance size / replica count
+    )
+    docdb.init(config)
+    atexit.register(docdb.shutdown)
+
+    @app.route("/health")
+    def health():
+        ok = docdb.get_client().ping()
+        return jsonify({"docdb": "ok" if ok else "unreachable"}), 200 if ok else 503
+
+    @app.route("/orders/<order_id>")
+    def get_order(order_id):
+        # get_client() returns the singleton (no new connection is opened)
+        db = docdb.get_client().db("shop")
+        order = db.orders.find_one({"_id": order_id})
+        if not order:
+            return jsonify({"error": "not found"}), 404
+        order["_id"] = str(order["_id"])
+        return jsonify(order)
+
+    return app
+
+
+if __name__ == "__main__":
+    create_app().run(debug=True)

--- a/developer/amazon-documentdb-python-client/examples/03_fastapi_app.py
+++ b/developer/amazon-documentdb-python-client/examples/03_fastapi_app.py
@@ -1,0 +1,50 @@
+"""
+Example 03 — FastAPI application
+
+FastAPI's lifespan context manager is the correct place to initialize
+and tear down the Amazon DocumentDB client. This replaces the deprecated
+@app.on_event("startup") pattern.
+"""
+
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, HTTPException
+import docdb
+from docdb.secrets import config_from_secret
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncGenerator:
+    # Startup - initialize the connection pool
+    config = config_from_secret(
+        "prod/shop/docdb",
+        region="us-east-1",
+        app_name="shop-api",
+        max_pool_size=50,
+    )
+    docdb.init(config)
+    yield
+    # Shutdown - drain the pool cleanly
+    docdb.shutdown()
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+@app.get("/health")
+def health():
+    ok = docdb.get_client().ping()
+    if not ok:
+        raise HTTPException(status_code=503, detail="Amazon DocumentDB unreachable")
+    return {"docdb": "ok"}
+
+
+@app.get("/orders/{order_id}")
+def get_order(order_id: str):
+    db = docdb.get_client().db("shop")
+    order = db.orders.find_one({"_id": order_id})
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found")
+    order["_id"] = str(order["_id"])
+    return order

--- a/developer/amazon-documentdb-python-client/examples/04_lambda.py
+++ b/developer/amazon-documentdb-python-client/examples/04_lambda.py
@@ -1,0 +1,56 @@
+"""
+Example 04 — AWS Lambda
+
+Lambda re-uses the execution environment between invocations.
+Initialize the client at module level (outside the handler function) so
+the connection pool is created once per container, not once per invocation.
+
+If the client is initialized inside the handler, every invocation opens
+a fresh pool and Amazon DocumentDB will see a surge of connections under any load.
+
+IMPORTANT: Lambda has a configurable concurrency limit. If your function
+can scale to N concurrent executions, Amazon DocumentDB will see up to
+  N * max_pool_size
+connections from this function alone. Size accordingly.
+"""
+
+import logging
+import docdb
+from docdb.secrets import config_from_secret
+from docdb import managed_cursor
+
+logger = logging.getLogger(__name__)
+
+# Module-level init — runs once per Lambda container (warm or cold start)
+_config = config_from_secret(
+    "prod/shop/docdb",
+    region="us-east-1",
+    app_name="shop-order-processor",
+    # Lambda concurrency * max_pool_size = total connections from this function.
+    # Keep this low for Lambda. The pool doesn't benefit from being large
+    # when each invocation handles a single request.
+    max_pool_size=5,
+    min_pool_size=1,
+)
+docdb.init(_config)
+
+# Handler
+def handler(event: dict, context) -> dict:
+    db = docdb.get_client().db("shop")
+
+    order_id = event.get("order_id")
+    if not order_id:
+        return {"statusCode": 400, "body": "missing order_id"}
+
+    order = db.orders.find_one({"_id": order_id})
+    if not order:
+        return {"statusCode": 404, "body": "not found"}
+
+    # Example - find all pending items for this order using managed_cursor
+    with managed_cursor(
+        db.order_items.find({"order_id": order_id, "status": "pending"})
+    ) as cur:
+        pending_items = [item["sku"] for item in cur]
+
+    logger.info("Processed order %s with %d pending items", order_id, len(pending_items))
+    return {"statusCode": 200, "pending_items": pending_items}

--- a/developer/amazon-documentdb-python-client/examples/05_telemetry.py
+++ b/developer/amazon-documentdb-python-client/examples/05_telemetry.py
@@ -1,0 +1,88 @@
+"""
+Example: Enabling telemetry to observe DocumentDB client behavior
+
+Telemetry emits named metrics and trace spans for:
+- Every command (find, insert, update, etc.) — count, duration, failures
+- Connection pool activity — opens, closes, pool size
+- Server heartbeats — duration, failures
+- Topology changes — servers added/removed from the replica set
+
+Two backends are available:
+- LOG: Emits structured log records (zero dependencies, use in dev/debug)
+- CLOUDWATCH: Publishes to Amazon CloudWatch Metrics (requires boto3)
+"""
+
+import logging
+
+import docdb
+from docdb import DocumentDBConfig
+from docdb.telemetry import MetricsBackend, TelemetryConfig
+
+# Configure logging to see telemetry output
+logging.basicConfig(level=logging.DEBUG, format="%(name)s | %(message)s")
+
+# --- Option A: Log-based telemetry (zero dependencies) ---
+
+config = DocumentDBConfig(
+    host="your-cluster.cluster-abc123.us-east-1.docdb.amazonaws.com",
+    username="admin",
+    password="secret",
+    app_name="inventory-service",
+    telemetry=TelemetryConfig(
+        enabled=True,
+        metrics_backend=MetricsBackend.LOG,
+    ),
+)
+
+docdb.init(config)
+client = docdb.get_client()
+
+# All operations now emit telemetry automatically:
+# [metric] docdb.commands.total += 1
+# [span:start] docdb.command.find
+# [span:end] docdb.command.find duration=3.2ms
+# [metric] docdb.commands.duration_ms: 3.2
+
+db = client.db("inventory")
+db.products.find_one({"sku": "ABC-123"})
+
+# Flush before shutdown to ensure all metrics are delivered
+client.telemetry.flush()
+docdb.shutdown()
+
+
+# --- Option B: CloudWatch Metrics (production) ---
+# Uncomment below for CloudWatch publishing:
+#
+# docdb.reset()
+# config = DocumentDBConfig(
+#     host="your-cluster.cluster-abc123.us-east-1.docdb.amazonaws.com",
+#     username="admin",
+#     password="secret",
+#     app_name="inventory-service",
+#     telemetry=TelemetryConfig(
+#         enabled=True,
+#         metrics_backend=MetricsBackend.CLOUDWATCH,
+#         cloudwatch_namespace="MyApp/DocumentDB",
+#         cloudwatch_flush_interval_seconds=30,
+#         default_dimensions={
+#             "service": "inventory-service",
+#             "environment": "prod",
+#         },
+#     ),
+# )
+# docdb.init(config)
+
+
+# --- Option C: Custom backend ---
+# Implement TelemetryBackend for Datadog, Prometheus, OTLP, etc.
+#
+# from docdb.telemetry import TelemetryBackend, MetricRecord, SpanContext
+#
+# class DatadogBackend(TelemetryBackend):
+#     def record_metric(self, metric: MetricRecord) -> None:
+#         statsd.increment(metric.name, metric.value, tags=metric.dimensions)
+#     def start_span(self, span: SpanContext) -> None: ...
+#     def end_span(self, span, duration_ms, error=None) -> None: ...
+#     def flush(self) -> None: ...
+#     def shutdown(self) -> None: ...

--- a/developer/amazon-documentdb-python-client/examples/06_custom_plugin.py
+++ b/developer/amazon-documentdb-python-client/examples/06_custom_plugin.py
@@ -1,0 +1,157 @@
+"""
+Example: Writing and registering a custom plugin
+
+This example shows how to create a plugin that:
+1. Logs every operation with timing
+2. Adds retry logic for reads
+3. Integrates into the plugin chain via registration + config
+
+Plugins are composabl. You can stack multiple plugins and they
+execute in weight order (lower weight = outermost = runs first).
+"""
+
+import sys
+import time
+
+sys.path.insert(0, "src")
+
+from docdb import (
+    BaseConnectionPlugin,
+    DocumentDBConfig,
+    PluginConfig,
+    register_plugin,
+)
+from docdb.plugins.base import WILDCARD, OperationContext
+
+
+# ─── Example 1: Simple audit/logging plugin ─────────────────────────────────
+
+class AuditPlugin(BaseConnectionPlugin):
+    """Logs every intercepted operation with timing."""
+
+    @property
+    def plugin_code(self):
+        return "audit"
+
+    @property
+    def weight(self):
+        return 150  # runs early (after telemetry at 100)
+
+    def subscribed_methods(self):
+        return frozenset({WILDCARD})  # observe all operations
+
+    def execute(self, ctx, next_fn):
+        start = time.perf_counter()
+        print(f"  [audit] {ctx.database_name}.{ctx.collection_name}.{ctx.method}()")
+        try:
+            result = next_fn(ctx)
+            duration = (time.perf_counter() - start) * 1000
+            print(f"  [audit] ✓ completed in {duration:.1f}ms")
+            return result
+        except Exception as exc:
+            duration = (time.perf_counter() - start) * 1000
+            print(f"  [audit] ✗ failed in {duration:.1f}ms: {exc}")
+            raise
+
+
+# Register the plugin so it can be referenced by code string
+register_plugin("audit", lambda **opts: AuditPlugin())
+
+
+# ─── Example 2: Retry plugin for reads ──────────────────────────────────────
+
+class RetryPlugin(BaseConnectionPlugin):
+    """Retries failed read operations with exponential backoff."""
+
+    READ_METHODS = frozenset({
+        "find", "find_one", "aggregate", "count_documents", "distinct",
+    })
+
+    def __init__(self, max_attempts: int = 3, base_delay_ms: float = 100):
+        self._max_attempts = max_attempts
+        self._base_delay_ms = base_delay_ms
+
+    @property
+    def plugin_code(self):
+        return "retry"
+
+    @property
+    def weight(self):
+        return 500  # runs in the middle
+
+    def subscribed_methods(self):
+        return self.READ_METHODS  # only intercept reads
+
+    def execute(self, ctx, next_fn):
+        last_error = None
+        for attempt in range(self._max_attempts):
+            try:
+                result = next_fn(ctx)
+                if attempt > 0:
+                    print(f"  [retry] succeeded on attempt {attempt + 1}")
+                return result
+            except Exception as exc:
+                last_error = exc
+                if attempt < self._max_attempts - 1:
+                    delay = self._base_delay_ms * (2 ** attempt) / 1000
+                    print(f"  [retry] attempt {attempt + 1} failed, "
+                          f"retrying in {delay * 1000:.0f}ms...")
+                    time.sleep(delay)
+        raise last_error
+
+
+# Register with configurable options
+register_plugin("retry", lambda **opts: RetryPlugin(
+    max_attempts=opts.get("max_attempts", 3),
+    base_delay_ms=opts.get("base_delay_ms", 100),
+))
+
+
+# ─── Usage ───────────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    import docdb
+
+    # Configure with plugins, auto-sorted by weight. E.g.:
+    #   telemetry (100) → audit (150) → retry (500) → DefaultPlugin (1000)
+    config = DocumentDBConfig(
+        host="localhost",
+        port=27017,
+        tls=False,
+        app_name="plugin-demo",
+        plugins=[
+            PluginConfig("audit"),
+            PluginConfig("retry", options={"max_attempts": 3}),
+        ],
+    )
+
+    docdb.init(config)
+    client = docdb.get_client()
+
+    print("\n" + "=" * 60)
+    print("  PLUGIN DEMO")
+    print("  Chain: DefaultPlugin ← retry ← audit")
+    print("=" * 60 + "\n")
+
+    db = client.db("demo")
+
+    print(">>> find_one (goes through audit + retry + default):")
+    try:
+        db.orders.find_one({"_id": "test-123"})
+    except Exception as e:
+        print(f"  Expected error (no DB running): {type(e).__name__}\n")
+
+    print(">>> insert_one (goes through audit + default, skips retry):")
+    try:
+        db.orders.insert_one({"name": "widget"})
+    except Exception as e:
+        print(f"  Expected error (no DB running): {type(e).__name__}\n")
+
+    print(">>> create_index (NOT intercepted — goes directly to PyMongo):")
+    try:
+        db.orders.create_index([("name", 1)])
+    except Exception as e:
+        print(f"  Expected error (no DB running): {type(e).__name__}\n")
+
+    docdb.shutdown()
+    print("Done.")

--- a/developer/amazon-documentdb-python-client/examples/07_iam_auth.py
+++ b/developer/amazon-documentdb-python-client/examples/07_iam_auth.py
@@ -1,0 +1,143 @@
+"""
+IAM Authentication Example — Verify password-less authentication works
+
+This script connects to Amazon DocumentDB using IAM authentication
+(no username/password), performs a simple operation, and shows the
+authentication mechanism in use.
+
+Prerequisites:
+    - Amazon DocumentDB 5.0+ cluster with IAM authentication enabled
+    - IAM role/user with rds-db:connect permission
+    - Database user created with the IAM identity ARN and MONGODB-AWS mechanism
+    - pip install 'amazon-documentdb-python-client[iam]'
+
+Environment variables:
+    DOCDB_HOST       — Cluster endpoint (required)
+    DOCDB_CA_FILE    — Path to CA bundle (default: global-bundle.pem)
+
+    For IAM role (Lambda, ECS, EKS, EC2):
+        N/A - credentials come from instance metadata
+
+    For IAM user (local dev, CI/CD):
+        AWS_ACCESS_KEY_ID       — IAM user access key
+        AWS_SECRET_ACCESS_KEY   — IAM user secret key
+        AWS_SESSION_TOKEN       — (optional, for assumed roles)
+
+Usage:
+    # On EC2/Lambda/ECS with IAM role attached:
+    export DOCDB_HOST="your-cluster.cluster-abc.us-east-1.docdb.amazonaws.com"
+    python examples/07_iam_auth.py
+
+    # On local dev with IAM user credentials:
+    export DOCDB_HOST="your-cluster.cluster-abc.us-east-1.docdb.amazonaws.com"
+    export AWS_ACCESS_KEY_ID="AKIA..."
+    export AWS_SECRET_ACCESS_KEY="..."
+    python examples/07_iam_auth.py
+"""
+
+import os
+import sys
+
+sys.path.insert(0, "src")
+
+HOST = os.environ.get("DOCDB_HOST", "")
+CA_FILE = os.environ.get("DOCDB_CA_FILE", "global-bundle.pem")
+
+if not HOST:
+    print("ERROR: Set DOCDB_HOST environment variable")
+    sys.exit(1)
+
+# Check pymongo[aws] is installed
+try:
+    import pymongo_auth_aws  # noqa: F401
+except ImportError:
+    print("ERROR: pymongo[aws] is not installed.")
+    print("       Run: pip install 'amazon-documentdb-python-client[iam]'")
+    sys.exit(1)
+
+# Connect with IAM auth
+import docdb
+from docdb import DocumentDBConfig
+
+print(f"\n{'=' * 70}")
+print(f"  IAM AUTHENTICATION TEST")
+print(f"  Host: {HOST}")
+print(f"{'=' * 70}\n")
+
+print("  Configuration:")
+print("    iam_auth=True")
+print("    (no username or password provided)\n")
+
+config = DocumentDBConfig(
+    host=HOST,
+    tls=True,
+    tls_ca_file=CA_FILE,
+    app_name="iam-auth-test",
+    iam_auth=True,
+)
+
+docdb.init(config)
+client = docdb.get_client()
+
+# Verify connection
+print("  >>> client.ping()")
+if client.ping():
+    print(" Connected successfully with IAM authentication\n")
+else:
+    print(" Connection failed.")
+    print("    Check:")
+    print("    - Is IAM authentication enabled on the cluster?")
+    print("    - Does the IAM role/user have rds-db:connect permission?")
+    print("    - Was a database user created with the IAM ARN?")
+    print("    - Is the cluster running Amazon DocumentDB 5.0+?")
+    docdb.shutdown()
+    sys.exit(1)
+
+# Show connection details
+print("  >>> Checking authentication mechanism on the connection...")
+raw_client = client.raw
+server_info = raw_client.admin.command("connectionStatus")
+auth_info = server_info.get("authInfo", {})
+users = auth_info.get("authenticatedUsers", [])
+print(f"  Authenticated as: {users}\n")
+
+# Perform a test operation
+print("  >>> db.iam_test.insert_one({'test': 'iam_auth_works'})")
+db = client.db("iam_auth_test")
+try:
+    db.iam_test.insert_one({"test": "iam_auth_works"})
+    print(" Write succeeded\n")
+
+    print("  >>> db.iam_test.find_one({'test': 'iam_auth_works'})")
+    result = db.iam_test.find_one({"test": "iam_auth_works"})
+    print(f" Read succeeded: {result}\n")
+
+    db.iam_test.drop()
+    print(" Cleanup complete\n")
+except Exception as e:
+    print(f" Operation failed: {type(e).__name__}: {e}")
+    print("    If authentication succeeded but the operation failed,")
+    print("    check that the database user has the correct roles.")
+    db.iam_test.drop()
+
+# Summary
+docdb.shutdown()
+
+print(f"{'=' * 70}")
+print("""  SUMMARY
+
+  IAM authentication verified:
+    • No username or password in the config
+    • Credentials retrieved automatically from environment/instance metadata
+    • Connection established via MONGODB-AWS auth mechanism
+    • Operations executed successfully
+
+  In production, this is all you need:
+
+    config = DocumentDBConfig(
+        host="your-cluster.cluster-abc.us-east-1.docdb.amazonaws.com",
+        app_name="my-service",
+        iam_auth=True,
+    )
+""")
+print(f"{'=' * 70}")

--- a/developer/amazon-documentdb-python-client/pyproject.toml
+++ b/developer/amazon-documentdb-python-client/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "amazon-documentdb-python-client"
+version = "0.1.0"
+description = "Amazon DocumentDB client for Python with best practices"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "Apache-2.0" }
+dependencies = [
+    "pymongo>=4.6,<5.0",
+]
+
+[project.optional-dependencies]
+secrets = [
+    "boto3>=1.34",
+]
+cloudwatch = [
+    "boto3>=1.34",
+]
+iam = [
+    "pymongo[aws]>=4.6,<5.0",
+]
+[tool.hatch.build.targets.wheel]
+packages = ["src/docdb"]

--- a/developer/amazon-documentdb-python-client/src/docdb/__init__.py
+++ b/developer/amazon-documentdb-python-client/src/docdb/__init__.py
@@ -1,0 +1,49 @@
+"""
+docdb — Amazon DocumentDB client for Python
+
+- Enforces Amazon DocumentDB best practices.
+
+Quickstart:
+    import docdb
+    from docdb.secrets import config_from_secret
+
+    # At app startup — once
+    config = config_from_secret("prod/myapp/docdb", app_name="my-service")
+    docdb.init(config)
+
+    # Anywhere in the app
+    client = docdb.get_client()
+    doc = client.db("mydb").orders.find_one({"_id": order_id})
+"""
+
+from importlib.metadata import PackageNotFoundError, version
+
+from .client import DocumentDBClient, get_client, init, reset, shutdown
+from .config import DocumentDBConfig
+from .cursor import find_all, managed_cursor
+from .plugins import (
+    BaseConnectionPlugin,
+    ConnectionPlugin,
+    PluginConfig,
+    register_plugin,
+)
+
+try:
+    __version__ = version("amazon-documentdb-python-client")
+except PackageNotFoundError:
+    __version__ = "0.0.0-dev"
+
+__all__ = [
+    "DocumentDBClient",
+    "DocumentDBConfig",
+    "get_client",
+    "init",
+    "shutdown",
+    "reset",
+    "managed_cursor",
+    "find_all",
+    "ConnectionPlugin",
+    "BaseConnectionPlugin",
+    "PluginConfig",
+    "register_plugin",
+]

--- a/developer/amazon-documentdb-python-client/src/docdb/client.py
+++ b/developer/amazon-documentdb-python-client/src/docdb/client.py
@@ -1,0 +1,333 @@
+"""
+Thread-safe singleton Amazon DocumentDB client.
+
+Usage pattern (app startup):
+    import docdb
+    docdb.init(config)          # once, at process start
+
+Usage pattern (anywhere in the app):
+    client = docdb.get_client()
+    db = client.db("mydb")
+    result = db.orders.find_one({"_id": order_id})
+"""
+
+import logging
+import os
+import threading
+from typing import Any
+
+from pymongo import MongoClient
+from pymongo.errors import PyMongoError
+
+from .config import DocumentDBConfig
+from .connection_tracker import ConnectionTracker
+from .plugins.chain import PluginChainBuilder, PluginConfig, PluginPipeline
+from .plugins.proxy import PluginAwareDatabase
+from .telemetry.backend import NoOpBackend, TelemetryBackend
+from .telemetry.config import TelemetryConfig, build_backend
+from .telemetry.listeners import (
+    DocumentDBCommandListener,
+    DocumentDBHeartbeatListener,
+    DocumentDBPoolListener,
+    DocumentDBTopologyListener,
+)
+
+logger = logging.getLogger(__name__)
+
+# Module-level singleton — one client per process
+_instance: "DocumentDBClient | None" = None
+_lock = threading.Lock()
+
+
+class DocumentDBClient:
+    """
+    Wraps PyMongo MongoClient with Amazon DocumentDB best practices enforced at construction.
+
+    Do not instantiate directly — use docdb.init() and docdb.get_client().
+    """
+
+    def __init__(self, config: DocumentDBConfig) -> None:
+        if not config.app_name:
+            logger.warning(
+                "DocumentDBConfig.app_name is not set. "
+                "Set it to your service name so operations can be attributed "
+                "to this service within log files."
+            )
+        self._config = config
+        self._telemetry_backend = self._build_telemetry_backend()
+        self._connection_tracker = ConnectionTracker(telemetry_backend=self._telemetry_backend)
+        self._client = self._build_client()
+        self._connection_tracker.set_client(self._client)
+        self._pipeline = self._build_pipeline()
+        logger.info(
+            "DocumentDBClient initialized",
+            extra={
+                "host": config.host,
+                "replica_set": config.replica_set,
+                "max_pool_size": config.max_pool_size,
+                "app_name": config.app_name,
+                "telemetry_enabled": not isinstance(self._telemetry_backend, NoOpBackend),
+            },
+        )
+
+    def _build_telemetry_backend(self) -> TelemetryBackend:
+        telemetry_config = self._config.telemetry
+        if telemetry_config is None:
+            return NoOpBackend()
+        if not isinstance(telemetry_config, TelemetryConfig):
+            raise TypeError(
+                "DocumentDBConfig.telemetry must be a TelemetryConfig instance. "
+                "Import it with: from docdb.telemetry import TelemetryConfig"
+            )
+        return build_backend(
+            telemetry_config,
+            host=self._config.host,
+            app_name=self._config.app_name,
+        )
+
+    _MANAGED_OPTIONS = frozenset({
+        "host",
+        "port",
+        "username",
+        "password",
+        "authSource",
+        "tls",
+        "tlsCAFile",
+        "tlsAllowInvalidCertificates",
+        "tlsAllowInvalidHostnames",
+        "tlsInsecure",
+        "replicaSet",
+        "directConnection",
+        "retryWrites",
+        "retryReads",
+        "readPreference",
+        "maxPoolSize",
+        "minPoolSize",
+        "maxIdleTimeMS",
+        "serverSelectionTimeoutMS",
+        "socketTimeoutMS",
+        "connectTimeoutMS",
+        "appName",
+        "event_listeners",
+        "authMechanism",
+    })
+
+    def _build_client(self) -> MongoClient:
+        conflicts = self._config.extra_options.keys() & self._MANAGED_OPTIONS
+        if conflicts:
+            raise ValueError(
+                f"extra_options cannot override managed settings: "
+                f"{', '.join(sorted(conflicts))}. "
+                f"Set these via DocumentDBConfig fields instead."
+            )
+
+        tls_opts: dict = {"tls": self._config.tls}
+        if self._config.tls:
+            if not os.path.exists(self._config.tls_ca_file):
+                raise FileNotFoundError(
+                    f"TLS CA file not found: {self._config.tls_ca_file}. "
+                    "Download from: https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem"
+                )
+            tls_opts["tlsCAFile"] = self._config.tls_ca_file
+
+        timeout_opts: dict = {
+            "serverSelectionTimeoutMS": self._config.server_selection_timeout_ms,
+            "connectTimeoutMS": self._config.connect_timeout_ms,
+        }
+        if self._config.socket_timeout_ms:
+            timeout_opts["socketTimeoutMS"] = self._config.socket_timeout_ms
+
+        telemetry_opts: dict = {}
+        event_listeners = self._build_event_listeners()
+        if event_listeners:
+            telemetry_opts["event_listeners"] = event_listeners
+
+        auth_opts: dict = {}
+        if self._config.iam_auth:
+            auth_opts["authMechanism"] = "MONGODB-AWS"
+        else:
+            auth_opts["username"] = self._config.username
+            auth_opts["password"] = self._config.password
+            auth_opts["authSource"] = self._config.auth_source
+
+        return MongoClient(
+            **self._config.extra_options,
+            host=self._config.host,
+            port=self._config.port,
+            **auth_opts,
+            **tls_opts,
+            replicaSet=self._config.replica_set,
+            directConnection=False,
+            retryWrites=False,
+            retryReads=True,
+            readPreference=self._config.read_preference,
+            maxPoolSize=self._config.max_pool_size,
+            minPoolSize=self._config.min_pool_size,
+            maxIdleTimeMS=self._config.max_idle_time_ms,
+            **timeout_opts,
+            appName=self._config.app_name,
+            **telemetry_opts,
+        )
+
+    def _build_event_listeners(self) -> list | None:
+        # Connection tracker is always active (cleans up stale connections)
+        listeners = [
+            self._connection_tracker.pool_listener,
+            self._connection_tracker.topology_listener,
+        ]
+
+        # Telemetry listeners are conditional
+        if not isinstance(self._telemetry_backend, NoOpBackend):
+            telemetry_config = self._config.telemetry
+            enabled = telemetry_config.enabled_listeners
+
+            if "command" in enabled:
+                listeners.append(DocumentDBCommandListener(
+                    self._telemetry_backend,
+                    emit_spans=telemetry_config.emit_spans,
+                ))
+            if "heartbeat" in enabled:
+                listeners.append(DocumentDBHeartbeatListener(self._telemetry_backend))
+            if "topology" in enabled:
+                listeners.append(DocumentDBTopologyListener(self._telemetry_backend))
+            if "pool" in enabled:
+                listeners.append(DocumentDBPoolListener(self._telemetry_backend))
+
+        return listeners
+
+    def _build_pipeline(self) -> PluginPipeline:
+        builder = PluginChainBuilder()
+        plugin_configs = [
+            cfg if isinstance(cfg, PluginConfig) else PluginConfig(**cfg)
+            for cfg in self._config.plugins
+        ]
+
+        # Auto-inject TelemetryPlugin if telemetry is enabled and not already listed
+        if not isinstance(self._telemetry_backend, NoOpBackend):
+            codes = {pc.code for pc in plugin_configs}
+            if "telemetry" not in codes:
+                plugin_configs.insert(0, PluginConfig("telemetry"))
+
+        extra_options: dict[str, Any] = {"config": self._config}
+        if not isinstance(self._telemetry_backend, NoOpBackend):
+            extra_options["backend"] = self._telemetry_backend
+
+        return builder.build(plugin_configs, extra_options=extra_options)
+
+    def db(self, name: str) -> PluginAwareDatabase:
+        """Return a plugin-aware database handle."""
+        raw_db = self._client[name]
+        return PluginAwareDatabase(raw_db, self._pipeline)
+
+    def __getitem__(self, name: str) -> PluginAwareDatabase:
+        """Support client['mydb'] access like native PyMongo."""
+        return self.db(name)
+
+    def __getattr__(self, name: str) -> PluginAwareDatabase:
+        """Support client.mydb access like native PyMongo."""
+        if name.startswith("_"):
+            raise AttributeError(name)
+        return self.db(name)
+
+    def start_session(self, **kwargs):
+        """Start a client session. Delegates to the underlying MongoClient."""
+        return self._client.start_session(**kwargs)
+
+    @property
+    def raw(self) -> MongoClient:
+        """
+        Escape hatch to the underlying PyMongo MongoClient.
+        Use only when the wrapper doesn't expose what you need.
+        """
+        return self._client
+
+    def ping(self) -> bool:
+        """Return True if the cluster is reachable. Useful for health checks."""
+        try:
+            self._client.admin.command("ping")
+            return True
+        except PyMongoError as exc:
+            logger.error("Amazon DocumentDB ping failed: %s", exc)
+            return False
+
+    @property
+    def connections(self) -> ConnectionTracker:
+        """Access the connection tracker (inspect open connections per host)."""
+        return self._connection_tracker
+
+    @property
+    def telemetry(self) -> TelemetryBackend:
+        """Access the telemetry backend (e.g., to flush or inspect)."""
+        return self._telemetry_backend
+
+    def close(self) -> None:
+        self._telemetry_backend.flush()
+        self._telemetry_backend.shutdown()
+        self._pipeline.close_all()
+        self._client.close()
+        logger.info("DocumentDBClient connection pool closed")
+
+    # Context manager support — useful in scripts and tests
+    def __enter__(self) -> "DocumentDBClient":
+        return self
+
+    def __exit__(self, *args) -> None:
+        self.close()
+
+
+# Module-level factory functions
+def init(config: DocumentDBConfig) -> DocumentDBClient:
+    """
+    Initialize the singleton client. Call once at application startup.
+
+    Raises RuntimeError if called more than once in the same process
+    (instead of silently discarding the new config).
+    """
+    global _instance
+    with _lock:
+        if _instance is not None:
+            raise RuntimeError(
+                "DocumentDBClient is already initialized. "
+                "Call docdb.init() exactly once at process startup. "
+                "Use docdb.get_client() to retrieve the existing instance."
+            )
+        _instance = DocumentDBClient(config)
+        return _instance
+
+
+def get_client() -> DocumentDBClient:
+    """
+    Retrieve the singleton client. Must call docdb.init() first.
+
+    Raises RuntimeError if init() has not been called — this surfaces the
+    anti-pattern of creating clients on-demand rather than at startup.
+    """
+    if _instance is None:
+        raise RuntimeError(
+            "DocumentDBClient is not initialized. "
+            "Call docdb.init(config) once at application startup "
+            "before calling get_client()."
+        )
+    return _instance
+
+
+def shutdown() -> None:
+    """
+    Gracefully close the connection pool and release the singleton.
+
+    Call this in your application's shutdown hook (e.g., atexit, SIGTERM
+    handler, FastAPI lifespan teardown, Flask teardown_appcontext).
+    After calling shutdown(), init() may be called again if needed.
+    """
+    global _instance
+    with _lock:
+        if _instance is not None:
+            _instance.close()
+            _instance = None
+
+
+def reset() -> None:
+    """
+    Alias for shutdown(). Exists for test readability.
+    """
+    shutdown()

--- a/developer/amazon-documentdb-python-client/src/docdb/config.py
+++ b/developer/amazon-documentdb-python-client/src/docdb/config.py
@@ -1,0 +1,173 @@
+"""
+Amazon DocumentDB connection configuration.
+
+All parameters are documented with the reason they exist
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_VALID_READ_PREFERENCES = frozenset({
+    "primary",
+    "primaryPreferred",
+    "secondary",
+    "secondaryPreferred",
+    "nearest",
+})
+
+
+@dataclass
+class DocumentDBConfig:
+    # -------------------------------------------------------------------------
+    # Required
+    # -------------------------------------------------------------------------
+    host: str
+    """Cluster endpoint (cluster-id.cluster-xxx.region.docdb.amazonaws.com).
+    Avoid using an instance endpoint — those bypass replica set routing."""
+
+    # -------------------------------------------------------------------------
+    # Auth
+    # -------------------------------------------------------------------------
+    username: str | None = None
+    password: str | None = field(default=None, repr=False)
+    auth_source: str = "admin"
+    port: int = 27017
+
+    iam_auth: bool = False
+    """Use IAM authentication instead of username/password.
+
+    When True, the wrapper passes authMechanism="MONGODB-AWS" to PyMongo,
+    which retrieves temporary credentials from AWS STS via environment
+    variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN)
+    or instance/task role.
+
+    Requirements:
+      - Amazon DocumentDB 5.0+ (instance-based clusters only)
+      - pip install 'pymongo[aws]'
+      - IAM user/role must NOT be the cluster's primary user
+      - TLS must be enabled (enforced by this wrapper)
+
+    Credentials are only used during connection establishment. Once
+    authenticated, the connection remains valid even if credentials rotate.
+    """
+
+    # -------------------------------------------------------------------------
+    # TLS — enabled by default
+    # -------------------------------------------------------------------------
+    tls: bool = True
+    """TLS is enabled by default on Amazon DocumentDB clusters and is strongly
+    recommended. Can be disabled on clusters configured without TLS, but
+    should not be False in production."""
+
+    tls_ca_file: str = "/etc/ssl/certs/global-bundle.pem"
+    """Path to the Amazon DocumentDB CA bundle.
+    Download: https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
+    Common locations:
+      - EC2/ECS container: /etc/ssl/certs/global-bundle.pem
+      - Lambda (via layer): /opt/global-bundle.pem
+    """
+
+    # -------------------------------------------------------------------------
+    # Replica set
+    # -------------------------------------------------------------------------
+    replica_set: str = "rs0"
+    """Amazon DocumentDB clusters use replica set name 'rs0'.
+    Without this, the driver treats the cluster as a standalone node and
+    will not re-route operations after a primary failover."""
+
+    # -------------------------------------------------------------------------
+    # Read preference
+    # ------------------------------------------------------------------------
+    read_preference: str = "secondaryPreferred"
+    """Route reads to replicas when available. Change to 'primary' only if
+    your application requires read-after-write consistency."""
+
+    # -------------------------------------------------------------------------
+    # Connection pool
+    # -------------------------------------------------------------------------
+    max_pool_size: int = 100
+    """Maximum connections per pool. Each MongoClient holds one pool per server
+    in the replica set. Tune based on your Amazon DocumentDB instance connection limit
+    Divide max_pool_size across all replicas x all app instances."""
+
+    min_pool_size: int = 5
+    """Keep this many connections warm. Avoids cold-start latency on burst traffic."""
+
+    max_idle_time_ms: int = 10_000
+    """Close connections idle longer than this. Prevents stale connections
+    from accumulating when traffic is bursty."""
+
+    # -------------------------------------------------------------------------
+    # Timeouts
+    # -------------------------------------------------------------------------
+    server_selection_timeout_ms: int = 30_000
+    """How long the driver waits to find a suitable server. Amazon DocumentDB
+    failovers typically complete within 30 seconds from start to finish.
+    This must be high enough to ride through a primary election without surfacing 
+    errors to the application."""
+
+    socket_timeout_ms: int = 0
+    """How long to wait for a response on an open socket. 0 means no timeout
+    (PyMongo default). Set a positive value only if you need to bound maximum
+    query duration. Amazon DocumentDB implements a 2-hour server-side timeout 
+    as a safety mechanism to limit runaway queries from consuming resources 
+    indefinitely."""
+
+    connect_timeout_ms: int = 10_000
+    """Timeout for establishing a new connection to a server."""
+
+    # -------------------------------------------------------------------------
+    # Observability
+    # -------------------------------------------------------------------------
+    app_name: str | None = None
+    """Appears in log output. Set this to your service name — it gives a way to 
+    attribute slow queries back to the originating service in a shared cluster.
+    Example: 'inventory-service', 'order-api'"""
+
+    # -------------------------------------------------------------------------
+    # Plugins
+    # -------------------------------------------------------------------------
+    plugins: list[Any] = field(default_factory=list)
+    """List of PluginConfig instances for the middleware chain.
+    Plugins are sorted by weight; DefaultPlugin is always appended last.
+    Import PluginConfig from docdb.plugins:
+        from docdb.plugins import PluginConfig
+        config = DocumentDBConfig(host=..., plugins=[PluginConfig("retry")])
+    """
+
+    # -------------------------------------------------------------------------
+    # Telemetry
+    # -------------------------------------------------------------------------
+    telemetry: Any = None
+    """TelemetryConfig instance to enable observability (metrics, traces).
+    When None, telemetry is disabled. Import TelemetryConfig from
+    docdb.telemetry to configure:
+        from docdb.telemetry import TelemetryConfig
+        config = DocumentDBConfig(host=..., telemetry=TelemetryConfig(enabled=True))
+    """
+
+    # -------------------------------------------------------------------------
+    # Additional options
+    # -------------------------------------------------------------------------
+    extra_options: dict[str, Any] = field(default_factory=dict)
+    """Additional keyword arguments passed directly to MongoClient.
+    Use for options not exposed above (e.g., compressors, event_listeners).
+    Enforced settings (retryWrites, directConnection, replicaSet) cannot be
+    overridden via extra_options."""
+
+    def __post_init__(self):
+        if self.read_preference not in _VALID_READ_PREFERENCES:
+            raise ValueError(
+                f"Invalid read_preference {self.read_preference!r}. "
+                f"Must be one of: {', '.join(sorted(_VALID_READ_PREFERENCES))}"
+            )
+        if self.iam_auth and (self.username or self.password):
+            logger.warning(
+                "iam_auth=True with username/password set. "
+                "IAM authentication will be used; username and password will be ignored."
+            )

--- a/developer/amazon-documentdb-python-client/src/docdb/connection_tracker.py
+++ b/developer/amazon-documentdb-python-client/src/docdb/connection_tracker.py
@@ -1,0 +1,177 @@
+"""
+Connection Tracker.
+
+Tracks open connections per host and forcibly closes all connections
+to a host when it is removed from the topology.
+
+Without this, stale connections to removed instances linger until PyMongo's
+server_selection_timeout_ms expires, causing delays during failover recovery.
+The tracker eliminates this by proactively cleaning up the moment the driver
+detects a topology change.
+
+This is implemented as PyMongo monitoring listeners because
+it operates at the connection lifecycle level, not the operation level.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import TYPE_CHECKING
+
+from pymongo import monitoring
+
+if TYPE_CHECKING:
+    from .telemetry.backend import TelemetryBackend
+
+logger = logging.getLogger(__name__)
+
+
+class ConnectionTracker:
+    """
+    Tracks connections per host and closes them on topology removal.
+
+    Registers as both a ConnectionPoolListener and TopologyListener.
+    When a server disappears from the topology, all tracked connections
+    to that host are immediately invalidated by clearing the pool.
+    """
+
+    def __init__(self, client=None, telemetry_backend: TelemetryBackend | None = None) -> None:
+        self._client = client
+        self._backend = telemetry_backend
+        self._connections: dict[tuple, int] = {}
+        self._lock = threading.Lock()
+
+    def set_client(self, client) -> None:
+        self._client = client
+
+    def set_backend(self, backend: TelemetryBackend) -> None:
+        self._backend = backend
+
+    @property
+    def pool_listener(self) -> "ConnectionTrackerPoolListener":
+        return ConnectionTrackerPoolListener(self)
+
+    @property
+    def topology_listener(self) -> "ConnectionTrackerTopologyListener":
+        return ConnectionTrackerTopologyListener(self)
+
+    def connection_opened(self, address: tuple) -> None:
+        with self._lock:
+            self._connections[address] = self._connections.get(address, 0) + 1
+
+    def connection_closed(self, address: tuple) -> None:
+        with self._lock:
+            count = self._connections.get(address, 0)
+            if count > 1:
+                self._connections[address] = count - 1
+            elif count == 1:
+                del self._connections[address]
+
+    def server_removed(self, address: tuple) -> None:
+        with self._lock:
+            count = self._connections.pop(address, 0)
+
+        if count > 0:
+            server_str = f"{address[0]}:{address[1]}"
+            logger.warning(
+                "ConnectionTracker: host %s removed from topology, "
+                "closing %d tracked connection(s)",
+                server_str, count,
+            )
+            self._emit_metric("docdb.tracker.pool_reset", count)
+            if self._client:
+                try:
+                    topology = self._client._topology
+                    topology.reset_server(address)
+                except Exception:
+                    logger.debug(
+                        "ConnectionTracker: could not reset server %s "
+                        "(pool may already be closed)",
+                        server_str,
+                    )
+
+    def _emit_metric(self, name: str, value: float = 1) -> None:
+        if self._backend:
+            from .telemetry.types import MetricRecord, MetricType
+            self._backend.record_metric(MetricRecord(
+                name=name,
+                value=value,
+                metric_type=MetricType.COUNTER,
+                unit="count",
+            ))
+
+    def get_connection_count(self, address: tuple) -> int:
+        with self._lock:
+            return self._connections.get(address, 0)
+
+    @property
+    def total_connections(self) -> int:
+        with self._lock:
+            return sum(self._connections.values())
+
+    @property
+    def hosts(self) -> dict[tuple, int]:
+        with self._lock:
+            return dict(self._connections)
+
+
+class ConnectionTrackerPoolListener(monitoring.ConnectionPoolListener):
+    """Feeds connection open/close events to the ConnectionTracker."""
+
+    def __init__(self, tracker: ConnectionTracker) -> None:
+        self._tracker = tracker
+
+    def pool_created(self, event: monitoring.PoolCreatedEvent) -> None:
+        pass
+
+    def pool_ready(self, event: monitoring.PoolReadyEvent) -> None:
+        pass
+
+    def pool_cleared(self, event: monitoring.PoolClearedEvent) -> None:
+        pass
+
+    def pool_closed(self, event: monitoring.PoolClosedEvent) -> None:
+        pass
+
+    def connection_created(self, event: monitoring.ConnectionCreatedEvent) -> None:
+        self._tracker.connection_opened(event.address)
+
+    def connection_ready(self, event: monitoring.ConnectionReadyEvent) -> None:
+        pass
+
+    def connection_closed(self, event: monitoring.ConnectionClosedEvent) -> None:
+        self._tracker.connection_closed(event.address)
+
+    def connection_check_out_started(self, event: monitoring.ConnectionCheckOutStartedEvent) -> None:
+        pass
+
+    def connection_check_out_failed(self, event: monitoring.ConnectionCheckOutFailedEvent) -> None:
+        pass
+
+    def connection_checked_out(self, event: monitoring.ConnectionCheckedOutEvent) -> None:
+        pass
+
+    def connection_checked_in(self, event: monitoring.ConnectionCheckedInEvent) -> None:
+        pass
+
+
+class ConnectionTrackerTopologyListener(monitoring.TopologyListener):
+    """Triggers connection cleanup when servers are removed from topology."""
+
+    def __init__(self, tracker: ConnectionTracker) -> None:
+        self._tracker = tracker
+
+    def opened(self, event: monitoring.TopologyOpenedEvent) -> None:
+        pass
+
+    def description_changed(self, event: monitoring.TopologyDescriptionChangedEvent) -> None:
+        prev_servers = set(event.previous_description.server_descriptions().keys())
+        new_servers = set(event.new_description.server_descriptions().keys())
+
+        removed = prev_servers - new_servers
+        for address in removed:
+            self._tracker.server_removed(address)
+
+    def closed(self, event: monitoring.TopologyClosedEvent) -> None:
+        pass

--- a/developer/amazon-documentdb-python-client/src/docdb/cursor.py
+++ b/developer/amazon-documentdb-python-client/src/docdb/cursor.py
@@ -1,0 +1,54 @@
+"""
+Managed cursor utilities.
+
+PyMongo cursors must be explicitly closed when you don't exhaust them.
+An un-exhausted, un-closed cursor holds a server-side cursor open until
+the server kills it (default 10 minutes). Under load, this depletes
+the server's cursor capacity and can cause query failures.
+
+Use managed_cursor() for any find() that uses limit(), skip(), or may
+break out of iteration early.
+"""
+
+import logging
+from contextlib import contextmanager
+from typing import Generator
+
+from pymongo.cursor import Cursor
+
+logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def managed_cursor(cursor: Cursor) -> Generator[Cursor, None, None]:
+    """
+    Context manager that guarantees cursor.close() is called.
+
+    Usage:
+        with managed_cursor(db.orders.find({"status": "open"}).limit(10)) as cur:
+            for doc in cur:
+                process(doc)
+        # cursor is closed here regardless of how iteration ended
+
+    When NOT needed:
+        Iterating a cursor to exhaustion (for doc in cursor: ...) closes it
+        automatically. managed_cursor() adds safety for early exits (break,
+        exception, limit/skip patterns).
+    """
+    try:
+        yield cursor
+    finally:
+        cursor.close()
+        logger.debug("Cursor closed via managed_cursor")
+
+
+def find_all(cursor: Cursor) -> list:
+    """
+    Convenience: exhaust a cursor into a list and close it.
+
+    Equivalent to list(cursor) but explicit about intent.
+    """
+    try:
+        return list(cursor)
+    finally:
+        cursor.close()

--- a/developer/amazon-documentdb-python-client/src/docdb/plugins/__init__.py
+++ b/developer/amazon-documentdb-python-client/src/docdb/plugins/__init__.py
@@ -1,0 +1,58 @@
+"""
+docdb.plugins — Composable plugin/middleware system.
+
+Plugins intercept collection operations (find, insert, update, etc.)
+and form an ordered chain sorted by weight. Each plugin declares which
+methods it subscribes to and can modify, observe, or short-circuit
+the operation before it reaches PyMongo.
+
+Quickstart:
+    from docdb.plugins import BaseConnectionPlugin, PluginConfig, register_plugin
+
+    class MyPlugin(BaseConnectionPlugin):
+        @property
+        def plugin_code(self):
+            return "my_plugin"
+
+        def execute(self, ctx, next_fn):
+            print(f"Before {ctx.method}")
+            result = next_fn(ctx)
+            print(f"After {ctx.method}")
+            return result
+
+    register_plugin("my_plugin", lambda **opts: MyPlugin())
+
+    config = DocumentDBConfig(
+        host="...",
+        plugins=[PluginConfig("my_plugin")],
+    )
+"""
+
+from .base import (
+    INTERCEPTABLE_METHODS,
+    WILDCARD,
+    BaseConnectionPlugin,
+    ConnectionPlugin,
+    OperationContext,
+)
+from .chain import PluginChainBuilder, PluginConfig, PluginPipeline
+from .proxy import PluginAwareCollection, PluginAwareDatabase
+from .registry import PLUGIN_REGISTRY, register_plugin
+
+# Trigger built-in plugin registrations
+from . import builtin as _builtin  # noqa: F401
+
+__all__ = [
+    "ConnectionPlugin",
+    "BaseConnectionPlugin",
+    "OperationContext",
+    "PluginConfig",
+    "PluginChainBuilder",
+    "PluginPipeline",
+    "PluginAwareDatabase",
+    "PluginAwareCollection",
+    "register_plugin",
+    "PLUGIN_REGISTRY",
+    "INTERCEPTABLE_METHODS",
+    "WILDCARD",
+]

--- a/developer/amazon-documentdb-python-client/src/docdb/plugins/base.py
+++ b/developer/amazon-documentdb-python-client/src/docdb/plugins/base.py
@@ -1,0 +1,106 @@
+"""
+Plugin system core types.
+
+Defines the plugin interface, base class, operation context, and the set
+of PyMongo collection methods that the plugin chain intercepts.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+INTERCEPTABLE_METHODS = frozenset({
+    "find",
+    "find_one",
+    "insert_one",
+    "insert_many",
+    "update_one",
+    "update_many",
+    "replace_one",
+    "delete_one",
+    "delete_many",
+    "aggregate",
+    "bulk_write",
+    "find_one_and_update",
+    "find_one_and_replace",
+    "find_one_and_delete",
+    "count_documents",
+    "distinct",
+})
+
+WILDCARD = "*"
+
+
+@dataclass
+class OperationContext:
+    """Carries state for a single operation through the plugin chain."""
+
+    method: str
+    collection_name: str
+    database_name: str
+    args: tuple
+    kwargs: dict[str, Any]
+    attributes: dict[str, Any] = field(default_factory=dict)
+
+
+class ConnectionPlugin(ABC):
+    """
+    Base interface for all plugins.
+
+    Plugins intercept collection operations routed through the proxy.
+    Each plugin declares which methods it cares about via subscribed_methods().
+    The chain builder only inserts a plugin for methods it subscribes to.
+    """
+
+    @property
+    @abstractmethod
+    def plugin_code(self) -> str:
+        """Unique identifier, e.g. 'telemetry', 'retry'."""
+
+    @property
+    def weight(self) -> int:
+        """
+        Execution order. Lower weight = outermost interceptor.
+        """
+        return 500
+
+    @abstractmethod
+    def subscribed_methods(self) -> frozenset[str]:
+        """
+        Method names this plugin intercepts.
+        Use WILDCARD ("*") to subscribe to all INTERCEPTABLE_METHODS.
+        """
+
+    @abstractmethod
+    def execute(
+        self,
+        ctx: OperationContext,
+        next_fn: Callable[[OperationContext], Any],
+    ) -> Any:
+        """
+        Intercept a single operation.
+
+        Call next_fn(ctx) to proceed to the next plugin in the chain.
+        """
+
+
+class BaseConnectionPlugin(ConnectionPlugin):
+    """
+    Pass-through implementation. Subclass and override only what you need.
+    """
+
+    @property
+    def plugin_code(self) -> str:
+        return self.__class__.__name__
+
+    def subscribed_methods(self) -> frozenset[str]:
+        return frozenset({WILDCARD})
+
+    def execute(
+        self,
+        ctx: OperationContext,
+        next_fn: Callable[[OperationContext], Any],
+    ) -> Any:
+        return next_fn(ctx)

--- a/developer/amazon-documentdb-python-client/src/docdb/plugins/builtin/__init__.py
+++ b/developer/amazon-documentdb-python-client/src/docdb/plugins/builtin/__init__.py
@@ -1,0 +1,36 @@
+"""Built-in plugin registrations."""
+
+from ..registry import register_plugin
+from .telemetry_plugin import TelemetryPlugin
+
+
+def _telemetry_factory(**opts):
+    backend = opts.get("backend")
+    if backend is None:
+        raise ValueError(
+            "TelemetryPlugin requires a 'backend' option. "
+            "This is normally injected automatically by DocumentDBClient."
+        )
+    return TelemetryPlugin(backend)
+
+
+register_plugin("telemetry", _telemetry_factory)
+
+
+from .retry_plugin import RetryPlugin
+
+
+def _retry_factory(**opts):
+    retry_methods = opts.get("retry_methods")
+    if retry_methods and isinstance(retry_methods, (list, set)):
+        retry_methods = frozenset(retry_methods)
+    return RetryPlugin(
+        max_attempts=opts.get("max_attempts", 3),
+        base_delay_ms=opts.get("base_delay_ms", 100),
+        max_delay_ms=opts.get("max_delay_ms", 5000),
+        retry_methods=retry_methods,
+        backend=opts.get("backend"),
+    )
+
+
+register_plugin("retry", _retry_factory)

--- a/developer/amazon-documentdb-python-client/src/docdb/plugins/builtin/default_plugin.py
+++ b/developer/amazon-documentdb-python-client/src/docdb/plugins/builtin/default_plugin.py
@@ -1,0 +1,35 @@
+"""
+DefaultPlugin — terminal plugin that calls the PyMongo method.
+
+Always appended last (weight=1000). The chain builder adds it
+unconditionally; it is never registered in the plugin registry.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from ..base import ConnectionPlugin, OperationContext, WILDCARD
+
+
+class DefaultPlugin(ConnectionPlugin):
+
+    @property
+    def plugin_code(self) -> str:
+        return "_default"
+
+    @property
+    def weight(self) -> int:
+        return 1000
+
+    def subscribed_methods(self) -> frozenset[str]:
+        return frozenset({WILDCARD})
+
+    def execute(
+        self,
+        ctx: OperationContext,
+        next_fn: Callable[[OperationContext], Any],
+    ) -> Any:
+        collection = ctx.attributes["_pymongo_collection"]
+        method = getattr(collection, ctx.method)
+        return method(*ctx.args, **ctx.kwargs)

--- a/developer/amazon-documentdb-python-client/src/docdb/plugins/builtin/retry_plugin.py
+++ b/developer/amazon-documentdb-python-client/src/docdb/plugins/builtin/retry_plugin.py
@@ -1,0 +1,143 @@
+"""
+Retry Plugin.
+
+Retries failed operations with exponential backoff and jitter.
+Configurable per method subscription — by default retries reads only,
+since retrying writes can cause duplicates unless idempotency is guaranteed.
+
+Follows the AWS Builders' Library guidance on timeouts, retries, and
+backoff with jitter:
+https://aws.amazon.com/builders-library/timeouts-retries-and-backoff-with-jitter/
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import time
+from typing import Any, Callable
+
+from pymongo.errors import (
+    AutoReconnect,
+    ConnectionFailure,
+    NetworkTimeout,
+    ServerSelectionTimeoutError,
+)
+
+from ..base import BaseConnectionPlugin, OperationContext
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_READ_METHODS = frozenset({
+    "find",
+    "find_one",
+    "count_documents",
+    "distinct",
+    "aggregate",
+})
+
+_RETRYABLE_ERRORS = (
+    AutoReconnect,
+    ConnectionFailure,
+    NetworkTimeout,
+    ServerSelectionTimeoutError,
+)
+
+
+class RetryPlugin(BaseConnectionPlugin):
+    """
+    Retries failed operations with exponential backoff and jitter.
+
+    Default behavior retries reads only (safe — no side effects).
+    To retry writes, explicitly include write method names in the
+    retry_methods option. Only do this if your writes are idempotent.
+    """
+
+    def __init__(
+        self,
+        max_attempts: int = 3,
+        base_delay_ms: float = 100,
+        max_delay_ms: float = 5000,
+        retry_methods: frozenset[str] | None = None,
+        backend=None,
+        config=None,
+        **kwargs: Any,
+    ) -> None:
+        if kwargs:
+            logger.warning(
+                "RetryPlugin: unrecognized options ignored: %s",
+                ", ".join(sorted(kwargs)),
+            )
+        self._max_attempts = max_attempts
+        self._base_delay_ms = base_delay_ms
+        self._max_delay_ms = max_delay_ms
+        self._retry_methods = retry_methods or _DEFAULT_READ_METHODS
+        self._backend = backend
+
+    @property
+    def plugin_code(self) -> str:
+        return "retry"
+
+    @property
+    def weight(self) -> int:
+        return 500
+
+    def subscribed_methods(self) -> frozenset[str]:
+        return self._retry_methods
+
+    def execute(
+        self,
+        ctx: OperationContext,
+        next_fn: Callable[[OperationContext], Any],
+    ) -> Any:
+        session = ctx.kwargs.get("session")
+        if session is not None and session.in_transaction:
+            return next_fn(ctx)
+
+        last_error: Exception | None = None
+        for attempt in range(self._max_attempts):
+            try:
+                result = next_fn(ctx)
+                if attempt > 0:
+                    logger.info(
+                        "RetryPlugin: %s.%s.%s succeeded on attempt %d",
+                        ctx.database_name, ctx.collection_name, ctx.method,
+                        attempt + 1,
+                    )
+                return result
+            except _RETRYABLE_ERRORS as exc:
+                last_error = exc
+                self._emit_metric("docdb.retry.triggered")
+                if attempt < self._max_attempts - 1:
+                    delay = self._calculate_delay(attempt)
+                    logger.warning(
+                        "RetryPlugin: %s.%s.%s attempt %d failed (%s), "
+                        "retrying in %.0fms...",
+                        ctx.database_name, ctx.collection_name, ctx.method,
+                        attempt + 1, type(exc).__name__, delay,
+                    )
+                    time.sleep(delay / 1000)
+                else:
+                    logger.error(
+                        "RetryPlugin: %s.%s.%s failed after %d attempts",
+                        ctx.database_name, ctx.collection_name, ctx.method,
+                        self._max_attempts,
+                    )
+                    self._emit_metric("docdb.retry.exhausted")
+        raise last_error  # type: ignore[misc]
+
+    def _emit_metric(self, name: str) -> None:
+        if self._backend:
+            from docdb.telemetry.types import MetricRecord, MetricType
+            self._backend.record_metric(MetricRecord(
+                name=name,
+                value=1,
+                metric_type=MetricType.COUNTER,
+                unit="count",
+            ))
+
+    def _calculate_delay(self, attempt: int) -> float:
+        """Exponential backoff with full jitter, capped at max_delay_ms."""
+        exponential = self._base_delay_ms * (2 ** attempt)
+        capped = min(exponential, self._max_delay_ms)
+        return random.uniform(0, capped)

--- a/developer/amazon-documentdb-python-client/src/docdb/plugins/builtin/telemetry_plugin.py
+++ b/developer/amazon-documentdb-python-client/src/docdb/plugins/builtin/telemetry_plugin.py
@@ -1,0 +1,82 @@
+"""
+TelemetryPlugin — operation-level spans and metrics through the plugin chain.
+
+Supplements (does not replace) the PyMongo DocumentDBCommandListener:
+- CommandListener: fires on every wire command, knows protocol details
+- TelemetryPlugin: fires on user operations, knows logical context
+  (collection name, method, duration including time in other plugins)
+
+Weight 100 — runs outermost so it measures total time including
+time spent by downstream plugins (e.g., retry delays).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Callable
+
+from docdb.telemetry.types import (
+    METRIC_COMMANDS_DURATION_MS,
+    METRIC_COMMANDS_FAILED,
+    MetricRecord,
+    MetricType,
+    SpanContext,
+)
+
+from ..base import BaseConnectionPlugin, OperationContext, WILDCARD
+
+
+class TelemetryPlugin(BaseConnectionPlugin):
+
+    def __init__(self, backend: Any) -> None:
+        self._backend = backend
+
+    @property
+    def plugin_code(self) -> str:
+        return "telemetry"
+
+    @property
+    def weight(self) -> int:
+        return 100
+
+    def subscribed_methods(self) -> frozenset[str]:
+        return frozenset({WILDCARD})
+
+    def execute(
+        self,
+        ctx: OperationContext,
+        next_fn: Callable[[OperationContext], Any],
+    ) -> Any:
+        span = SpanContext(
+            name=f"docdb.plugin.{ctx.method}",
+            attributes={
+                "collection": ctx.collection_name,
+                "db": ctx.database_name,
+                "method": ctx.method,
+            },
+        )
+        self._backend.start_span(span)
+        start = time.perf_counter()
+        try:
+            result = next_fn(ctx)
+            duration_ms = (time.perf_counter() - start) * 1000
+            self._backend.end_span(span, duration_ms)
+            self._backend.record_metric(MetricRecord(
+                name=METRIC_COMMANDS_DURATION_MS,
+                value=duration_ms,
+                metric_type=MetricType.HISTOGRAM,
+                unit="ms",
+                dimensions={"method": ctx.method, "collection": ctx.collection_name},
+            ))
+            return result
+        except Exception as exc:
+            duration_ms = (time.perf_counter() - start) * 1000
+            self._backend.end_span(span, duration_ms, error=exc)
+            self._backend.record_metric(MetricRecord(
+                name=METRIC_COMMANDS_FAILED,
+                value=1,
+                metric_type=MetricType.COUNTER,
+                unit="count",
+                dimensions={"method": ctx.method, "collection": ctx.collection_name},
+            ))
+            raise

--- a/developer/amazon-documentdb-python-client/src/docdb/plugins/chain.py
+++ b/developer/amazon-documentdb-python-client/src/docdb/plugins/chain.py
@@ -1,0 +1,109 @@
+"""
+Plugin chain builder and pipeline.
+
+PluginChainBuilder resolves plugin configs to instances, sorts by weight,
+and appends DefaultPlugin. PluginPipeline pre-builds a per-method dispatch
+table of closures for zero-overhead call routing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from .base import (
+    INTERCEPTABLE_METHODS,
+    WILDCARD,
+    ConnectionPlugin,
+    OperationContext,
+)
+from .builtin.default_plugin import DefaultPlugin
+from .registry import PLUGIN_REGISTRY
+
+
+@dataclass
+class PluginConfig:
+    """Declares a plugin to include in the chain."""
+
+    code: str
+    options: dict[str, Any] = field(default_factory=dict)
+
+
+class PluginPipeline:
+    """
+    Pre-built, per-method dispatch table.
+
+    For each method in INTERCEPTABLE_METHODS, a closure chain is built
+    at init time. Per-call cost is a single dict lookup + closure invocation.
+    """
+
+    def __init__(self, plugins: list[ConnectionPlugin]) -> None:
+        self._plugins = plugins
+        self._dispatch: dict[str, Callable[[OperationContext], Any]] = {}
+        for method in INTERCEPTABLE_METHODS:
+            self._dispatch[method] = self._build_chain_for_method(method, plugins)
+
+    def _build_chain_for_method(
+        self,
+        method: str,
+        plugins: list[ConnectionPlugin],
+    ) -> Callable[[OperationContext], Any]:
+        active = [
+            p for p in plugins
+            if WILDCARD in p.subscribed_methods()
+            or method in p.subscribed_methods()
+        ]
+
+        def _make_chain(remaining: list[ConnectionPlugin]) -> Callable[[OperationContext], Any]:
+            head = remaining[0]
+            if len(remaining) == 1:
+                return lambda ctx: head.execute(ctx, None)  # type: ignore[arg-type]
+            tail = _make_chain(remaining[1:])
+            return lambda ctx, _h=head, _t=tail: _h.execute(ctx, _t)
+
+        return _make_chain(active)
+
+    def invoke(self, ctx: OperationContext) -> Any:
+        chain_fn = self._dispatch.get(ctx.method)
+        if chain_fn is None:
+            raise ValueError(f"Method {ctx.method!r} is not interceptable")
+        return chain_fn(ctx)
+
+    def close_all(self) -> None:
+        """Close all plugins that implement a close() method."""
+        for plugin in self._plugins:
+            if hasattr(plugin, "close") and callable(plugin.close):
+                plugin.close()
+
+
+class PluginChainBuilder:
+    """Resolves PluginConfig specs to instances, sorts by weight, appends DefaultPlugin."""
+
+    def build(
+        self,
+        plugin_configs: list[PluginConfig],
+        extra_options: dict[str, Any] | None = None,
+    ) -> PluginPipeline:
+        """
+        Build the pipeline from plugin configs.
+
+        extra_options are merged into each plugin's options (e.g., telemetry
+        backend injected by DocumentDBClient).
+        """
+        plugins: list[ConnectionPlugin] = []
+        merged_extra = extra_options or {}
+
+        for cfg in plugin_configs:
+            factory = PLUGIN_REGISTRY.get(cfg.code)
+            if factory is None:
+                raise ValueError(
+                    f"Unknown plugin code {cfg.code!r}. "
+                    f"Available: {sorted(PLUGIN_REGISTRY)}"
+                )
+            opts = {**merged_extra, **cfg.options}
+            plugins.append(factory(**opts))
+
+        plugins.sort(key=lambda p: p.weight)
+        plugins.append(DefaultPlugin())
+
+        return PluginPipeline(plugins)

--- a/developer/amazon-documentdb-python-client/src/docdb/plugins/proxy.py
+++ b/developer/amazon-documentdb-python-client/src/docdb/plugins/proxy.py
@@ -1,0 +1,170 @@
+"""
+Proxy layer — PluginAwareDatabase and PluginAwareCollection.
+
+Transparent delegation proxies that intercept INTERCEPTABLE_METHODS
+and route them through the plugin pipeline. All other attribute access
+delegates directly to the underlying PyMongo objects.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pymongo.collection import Collection
+from pymongo.database import Database
+
+from .base import INTERCEPTABLE_METHODS, OperationContext
+from .chain import PluginPipeline
+
+
+class PluginAwareCollection:
+    """
+    Transparent proxy for pymongo.Collection.
+
+    Interceptable methods route through the PluginPipeline.
+    All other attributes delegate directly to the underlying Collection.
+    """
+
+    __slots__ = ("_collection", "_pipeline", "_db_name", "_interceptors")
+
+    def __init__(
+        self,
+        collection: Collection,
+        pipeline: PluginPipeline,
+        db_name: str,
+    ) -> None:
+        object.__setattr__(self, "_collection", collection)
+        object.__setattr__(self, "_pipeline", pipeline)
+        object.__setattr__(self, "_db_name", db_name)
+        object.__setattr__(self, "_interceptors", {
+            m: self._make_interceptor(m) for m in INTERCEPTABLE_METHODS
+        })
+
+    def __getattr__(self, name: str) -> Any:
+        if name in INTERCEPTABLE_METHODS:
+            return self._interceptors[name]
+        attr = getattr(self._collection, name)
+        if isinstance(attr, Collection):
+            return PluginAwareCollection(attr, self._pipeline, self._db_name)
+        if name in _COL_METHODS_RETURNING_COLLECTION and callable(attr):
+            return self._wrap_collection_method(attr)
+        return attr
+
+    def _wrap_collection_method(self, method):
+        pipeline = self._pipeline
+        db_name = self._db_name
+
+        def wrapper(*args, **kwargs):
+            result = method(*args, **kwargs)
+            if isinstance(result, Collection):
+                return PluginAwareCollection(result, pipeline, db_name)
+            return result
+        return wrapper
+
+    def __getitem__(self, name: str) -> PluginAwareCollection:
+        sub = self._collection[name]
+        return PluginAwareCollection(sub, self._pipeline, self._db_name)
+
+    def _make_interceptor(self, method: str):
+        collection = self._collection
+        pipeline = self._pipeline
+        db_name = self._db_name
+        col_name = collection.name
+
+        def interceptor(*args: Any, **kwargs: Any) -> Any:
+            ctx = OperationContext(
+                method=method,
+                collection_name=col_name,
+                database_name=db_name,
+                args=args,
+                kwargs=kwargs,
+                attributes={"_pymongo_collection": collection},
+            )
+            return pipeline.invoke(ctx)
+        return interceptor
+
+    def __repr__(self) -> str:
+        return repr(self._collection)
+
+    def __eq__(self, other) -> bool:
+        if isinstance(other, PluginAwareCollection):
+            return self._collection == other._collection
+        if isinstance(other, Collection):
+            return self._collection == other
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash(self._collection)
+
+    def __bool__(self) -> bool:
+        return bool(self._collection)
+
+
+_DB_METHODS_RETURNING_COLLECTION = frozenset({
+    "get_collection",
+    "create_collection",
+    "with_options",
+})
+
+_COL_METHODS_RETURNING_COLLECTION = frozenset({
+    "with_options",
+})
+
+
+class PluginAwareDatabase:
+    """
+    Transparent proxy for pymongo.Database.
+
+    Returns PluginAwareCollection from attribute/item access.
+    Everything else delegates to the underlying Database.
+    """
+
+    __slots__ = ("_database", "_pipeline")
+
+    def __init__(self, database: Database, pipeline: PluginPipeline) -> None:
+        object.__setattr__(self, "_database", database)
+        object.__setattr__(self, "_pipeline", pipeline)
+
+    def __getattr__(self, name: str) -> Any:
+        attr = getattr(self._database, name)
+        if isinstance(attr, Collection):
+            return PluginAwareCollection(attr, self._pipeline, self._database.name)
+        if name in _DB_METHODS_RETURNING_COLLECTION and callable(attr):
+            return self._wrap_collection_method(attr)
+        return attr
+
+    def __getitem__(self, name: str) -> PluginAwareCollection:
+        col = self._database[name]
+        return PluginAwareCollection(col, self._pipeline, self._database.name)
+
+    def _wrap_collection_method(self, method):
+        pipeline = self._pipeline
+        db_name = self._database.name
+
+        def wrapper(*args, **kwargs):
+            result = method(*args, **kwargs)
+            if isinstance(result, Collection):
+                return PluginAwareCollection(result, pipeline, db_name)
+            return result
+        return wrapper
+
+    def __repr__(self) -> str:
+        return repr(self._database)
+
+    def __eq__(self, other) -> bool:
+        if isinstance(other, PluginAwareDatabase):
+            return self._database == other._database
+        if isinstance(other, Database):
+            return self._database == other
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash(self._database)
+
+    def __bool__(self) -> bool:
+        return bool(self._database)
+
+    @property
+    def raw(self) -> Database:
+        """Escape hatch to the underlying pymongo.Database."""
+        return self._database

--- a/developer/amazon-documentdb-python-client/src/docdb/plugins/registry.py
+++ b/developer/amazon-documentdb-python-client/src/docdb/plugins/registry.py
@@ -1,0 +1,25 @@
+"""
+Plugin registry — maps plugin codes to factory callables.
+
+Populated at import time by built-in modules and by user calls
+to register_plugin().
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from .base import ConnectionPlugin
+
+PLUGIN_REGISTRY: dict[str, Callable[..., ConnectionPlugin]] = {}
+
+
+def register_plugin(code: str, factory: Callable[..., ConnectionPlugin]) -> None:
+    """
+    Register a plugin factory under the given code string.
+
+    Factory receives **kwargs from PluginConfig.options at chain-build time.
+    """
+    if code in PLUGIN_REGISTRY:
+        raise ValueError(f"Plugin code {code!r} is already registered.")
+    PLUGIN_REGISTRY[code] = factory

--- a/developer/amazon-documentdb-python-client/src/docdb/secrets.py
+++ b/developer/amazon-documentdb-python-client/src/docdb/secrets.py
@@ -1,0 +1,129 @@
+"""
+AWS Secrets Manager integration.
+
+The recommended pattern is to store connection credentials in Secrets 
+Manager and retrieve them at startup. This module makes that the path 
+of least resistance.
+
+Supports both the native format:
+{
+    "username":            "appuser",
+    "password":            "...",
+    "engine":              "mongo",
+    "host":                "cluster.cluster-xxx.us-east-1.docdb.amazonaws.com",
+    "port":                27017,
+    "ssl":                 true,
+    "dbClusterIdentifier": "mycluster"
+}
+
+...and a custom format with DocumentDBConfig field names:
+{
+    "host":        "cluster.cluster-xxx.us-east-1.docdb.amazonaws.com",
+    "port":        27017,
+    "username":    "appuser",
+    "password":    "...",
+    "tls_ca_file": "/etc/ssl/certs/global-bundle.pem"
+}
+
+The secret must contain host, username, and password. All other fields
+fall back to DocumentDBConfig defaults if not present.
+Any keyword arguments passed to config_from_secret() override both the
+secret and the defaults — use this for per-service settings like app_name
+and max_pool_size that don't belong in a shared secret.
+"""
+
+import json
+import logging
+from dataclasses import fields as dataclass_fields
+from typing import Any
+
+try:
+    import boto3
+except ImportError:
+    boto3 = None  # type: ignore[assignment]
+
+from .config import DocumentDBConfig
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_FIELD_NAMES = {f.name for f in dataclass_fields(DocumentDBConfig)}
+
+_DEFAULT_FIELD_ALIASES: dict[str, str] = {}
+
+
+def config_from_secret(
+    secret_name: str,
+    region: str = "us-east-1",
+    secrets_client=None,
+    field_aliases: dict[str, str] | None = None,
+    **overrides: Any,
+) -> DocumentDBConfig:
+    """
+    Load a DocumentDBConfig from an AWS Secrets Manager secret.
+
+    Args:
+        secret_name:    The secret name or ARN.
+        region:         AWS region where the secret is stored.
+        secrets_client: Optional pre-built boto3 Secrets Manager client.
+                        When provided, ``region`` is ignored.
+        field_aliases:  Optional mapping of secret field names to
+                        DocumentDBConfig field names. Use when your secret
+                        uses non-standard keys that need to map to config
+                        fields (e.g., {"db_host": "host"}).
+        **overrides:    Any DocumentDBConfig field values that should override
+                        the secret. Common use: app_name, max_pool_size.
+
+    Returns:
+        A fully populated DocumentDBConfig.
+
+    Example:
+        config = config_from_secret(
+            "prod/myapp/docdb",
+            region="us-east-1",
+            app_name="inventory-service",
+            max_pool_size=50,
+        )
+    """
+    if secrets_client is None and boto3 is None:
+        raise ImportError(
+            "boto3 is required for Secrets Manager integration. "
+        )
+
+    client = secrets_client or boto3.client("secretsmanager", region_name=region)
+    response = client.get_secret_value(SecretId=secret_name)
+
+    if "SecretString" not in response:
+        raise ValueError(
+            f"Secret {secret_name!r} does not contain a SecretString. "
+        )
+
+    secret: dict = json.loads(response["SecretString"])
+
+    logger.info("Loaded config from secret: %s", secret_name)
+
+    aliases = field_aliases if field_aliases is not None else _DEFAULT_FIELD_ALIASES
+    normalized = {aliases.get(k, k): v for k, v in secret.items()}
+
+    # Merge: secret values < config defaults < caller overrides
+    # Unknown keys in the secret are silently ignored so the secret can carry
+    # extra metadata (e.g., "engine", "dbClusterIdentifier") without breaking
+    # deserialization
+    merged = {
+        k: v
+        for k, v in {**normalized, **overrides}.items()
+        if k in _CONFIG_FIELD_NAMES
+    }
+
+    # Secrets Manager secrets should always contain credentials — unlike
+    # DocumentDBConfig (which allows None for local dev or IAM auth),
+    # a secret without credentials is a misconfiguration.
+    _REQUIRED_FIELDS = {"host", "username", "password"}
+    missing = _REQUIRED_FIELDS - merged.keys()
+    if missing:
+        raise ValueError(
+            f"Secret {secret_name!r} is missing required fields: "
+            f"{', '.join(sorted(missing))}. "
+            "Ensure the secret contains host, username, and password."
+        )
+
+    return DocumentDBConfig(**merged)

--- a/developer/amazon-documentdb-python-client/src/docdb/telemetry/__init__.py
+++ b/developer/amazon-documentdb-python-client/src/docdb/telemetry/__init__.py
@@ -1,0 +1,75 @@
+"""
+docdb.telemetry — Observability for Amazon DocumentDB connections.
+
+Provides pluggable telemetry backends (logging, CloudWatch) that receive
+metrics and trace spans from PyMongo's monitoring hooks. 
+
+Quickstart:
+    from docdb import DocumentDBConfig
+    from docdb.telemetry import TelemetryConfig, MetricsBackend
+
+    config = DocumentDBConfig(
+        host="cluster.docdb.amazonaws.com",
+        telemetry=TelemetryConfig(
+            enabled=True,
+            metrics_backend=MetricsBackend.LOG,
+        ),
+    )
+"""
+
+from .backend import NoOpBackend, TelemetryBackend
+from .cloudwatch_backend import CloudWatchBackend
+from .config import TelemetryConfig, build_backend
+from .listeners import (
+    DocumentDBCommandListener,
+    DocumentDBHeartbeatListener,
+    DocumentDBPoolListener,
+    DocumentDBTopologyListener,
+)
+from .log_backend import LogBackend
+from .types import (
+    METRIC_COMMANDS_DURATION_MS,
+    METRIC_COMMANDS_FAILED,
+    METRIC_COMMANDS_TOTAL,
+    METRIC_CONNECTIONS_CLOSED,
+    METRIC_CONNECTIONS_OPENED,
+    METRIC_SERVER_HEARTBEAT_DURATION_MS,
+    METRIC_SERVER_HEARTBEAT_FAILED,
+    METRIC_TOPOLOGY_CHANGED,
+    MetricRecord,
+    MetricType,
+    MetricsBackend,
+    SpanContext,
+    TracesBackend,
+)
+
+__all__ = [
+    # Config
+    "TelemetryConfig",
+    "build_backend",
+    # Backends
+    "TelemetryBackend",
+    "NoOpBackend",
+    "LogBackend",
+    "CloudWatchBackend",
+    # Listeners
+    "DocumentDBCommandListener",
+    "DocumentDBHeartbeatListener",
+    "DocumentDBPoolListener",
+    "DocumentDBTopologyListener",
+    # Types
+    "MetricsBackend",
+    "TracesBackend",
+    "MetricType",
+    "MetricRecord",
+    "SpanContext",
+    # Metric names
+    "METRIC_COMMANDS_TOTAL",
+    "METRIC_COMMANDS_FAILED",
+    "METRIC_COMMANDS_DURATION_MS",
+    "METRIC_CONNECTIONS_OPENED",
+    "METRIC_CONNECTIONS_CLOSED",
+    "METRIC_SERVER_HEARTBEAT_DURATION_MS",
+    "METRIC_SERVER_HEARTBEAT_FAILED",
+    "METRIC_TOPOLOGY_CHANGED",
+]

--- a/developer/amazon-documentdb-python-client/src/docdb/telemetry/backend.py
+++ b/developer/amazon-documentdb-python-client/src/docdb/telemetry/backend.py
@@ -1,0 +1,51 @@
+"""
+Abstract telemetry backend interface.
+
+All backends implement TelemetryBackend. The wrapper calls record_metric()
+and start_span()/end_span(). The backend decides where they go.
+"""
+
+from abc import ABC, abstractmethod
+
+from .types import MetricRecord, SpanContext
+
+
+class TelemetryBackend(ABC):
+    @abstractmethod
+    def record_metric(self, metric: MetricRecord) -> None:
+        """Emit a single metric data point."""
+
+    @abstractmethod
+    def start_span(self, span: SpanContext) -> None:
+        """Begin a trace span."""
+
+    @abstractmethod
+    def end_span(self, span: SpanContext, duration_ms: float, error: Exception | None = None) -> None:
+        """End a trace span with duration and optional error."""
+
+    @abstractmethod
+    def flush(self) -> None:
+        """Flush any buffered telemetry data."""
+
+    @abstractmethod
+    def shutdown(self) -> None:
+        """Release resources held by the backend."""
+
+
+class NoOpBackend(TelemetryBackend):
+    """Disabled telemetry — all operations are no-ops."""
+
+    def record_metric(self, metric: MetricRecord) -> None:
+        pass
+
+    def start_span(self, span: SpanContext) -> None:
+        pass
+
+    def end_span(self, span: SpanContext, duration_ms: float, error: Exception | None = None) -> None:
+        pass
+
+    def flush(self) -> None:
+        pass
+
+    def shutdown(self) -> None:
+        pass

--- a/developer/amazon-documentdb-python-client/src/docdb/telemetry/cloudwatch_backend.py
+++ b/developer/amazon-documentdb-python-client/src/docdb/telemetry/cloudwatch_backend.py
@@ -1,0 +1,130 @@
+"""
+CloudWatch Metrics telemetry backend.
+
+Buffers metric data points and publishes them to Amazon CloudWatch
+in batches. Only emits explicit metrics from record_metric() — span
+lifecycle (start/end) is intentionally not converted to additional
+metrics to avoid duplication and dimension fragmentation.
+
+Requires: boto3 (install via `pip install amazon-documentdb-python-client[cloudwatch]`)
+"""
+
+import logging
+import threading
+import time
+from collections import deque
+from typing import Any
+
+from .backend import TelemetryBackend
+from .types import MetricRecord, MetricType, SpanContext
+
+logger = logging.getLogger("docdb.telemetry.cloudwatch")
+
+_BATCH_SIZE = 20  # CloudWatch put_metric_data limit
+_FLUSH_INTERVAL_SECONDS = 60
+
+class CloudWatchBackend(TelemetryBackend):
+    """
+    Publishes metrics to Amazon CloudWatch Metrics.
+
+    Only record_metric() produces CloudWatch data points. Spans are
+    silently ignored — the CommandListener already emits duration as
+    an explicit metric, so converting spans would create duplicates.
+    """
+
+    def __init__(
+        self,
+        namespace: str = "DocumentDB/Client",
+        cloudwatch_client: Any = None,
+        flush_interval_seconds: float = _FLUSH_INTERVAL_SECONDS,
+        default_dimensions: dict[str, str] | None = None,
+    ) -> None:
+        try:
+            import boto3
+        except ImportError as e:
+            raise ImportError(
+                "boto3 is required for CloudWatch telemetry. "
+            ) from e
+
+        self._namespace = namespace
+        self._client = cloudwatch_client or boto3.client("cloudwatch")
+        self._default_dimensions = default_dimensions or {}
+        self._buffer: deque[dict] = deque()
+        self._lock = threading.Lock()
+        self._flush_interval = flush_interval_seconds
+        self._running = True
+        self._flush_thread = threading.Thread(
+            target=self._periodic_flush, daemon=True, name="docdb-cw-flush"
+        )
+        self._flush_thread.start()
+
+    def record_metric(self, metric: MetricRecord) -> None:
+        dimensions = {**self._default_dimensions, **metric.dimensions}
+        cw_dimensions = [{"Name": k, "Value": v} for k, v in dimensions.items()]
+
+        unit = self._map_unit(metric.unit, metric.metric_type)
+
+        datum: dict = {
+            "MetricName": metric.name,
+            "Value": metric.value,
+            "Unit": unit,
+            "Dimensions": cw_dimensions,
+        }
+
+        with self._lock:
+            self._buffer.append(datum)
+
+    def start_span(self, span: SpanContext) -> None:
+        pass
+
+    def end_span(self, span: SpanContext, duration_ms: float, error: Exception | None = None) -> None:
+        pass
+
+    def flush(self) -> None:
+        with self._lock:
+            batches = self._flush_buffer()
+        self._send_batches(batches)
+
+    def shutdown(self) -> None:
+        self._running = False
+        self.flush()
+
+    def _flush_buffer(self) -> list[list[dict]]:
+        # Drain buffer under lock, then send outside the lock
+        batches = []
+        while self._buffer:
+            batch = []
+            for _ in range(min(_BATCH_SIZE, len(self._buffer))):
+                batch.append(self._buffer.popleft())
+            batches.append(batch)
+        return batches
+
+    def _send_batches(self, batches: list) -> None:
+        for batch in batches:
+            try:
+                self._client.put_metric_data(
+                    Namespace=self._namespace, MetricData=batch
+                )
+            except Exception:
+                logger.exception("Failed to publish metrics to CloudWatch")
+
+    def _periodic_flush(self) -> None:
+        while self._running:
+            time.sleep(self._flush_interval)
+            if self._buffer:
+                self.flush()
+
+    @staticmethod
+    def _map_unit(unit: str, metric_type: MetricType) -> str:
+        unit_map = {
+            "ms": "Milliseconds",
+            "s": "Seconds",
+            "bytes": "Bytes",
+            "count": "Count",
+            "": "None",
+        }
+        if unit in unit_map:
+            return unit_map[unit]
+        if metric_type == MetricType.COUNTER:
+            return "Count"
+        return "None"

--- a/developer/amazon-documentdb-python-client/src/docdb/telemetry/config.py
+++ b/developer/amazon-documentdb-python-client/src/docdb/telemetry/config.py
@@ -1,0 +1,121 @@
+"""
+Telemetry configuration.
+
+Namespace and dimension strategy:
+- Namespace: auto-derived from the cluster endpoint as "DocumentDB/{cluster-id}"
+  to provide per-cluster views by default.
+- Dimensions: "service" (from app_name) and "environment" (if provided) are
+  added to every metric automatically. Filter by service or see all
+  services hitting a cluster in one namespace.
+"""
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from .backend import NoOpBackend, TelemetryBackend
+from .types import MetricsBackend, TracesBackend
+
+_CLUSTER_ID_PATTERN = re.compile(r"^([^.]+)\.cluster")
+
+
+def _extract_cluster_id(host: str) -> str:
+    """
+    Extract the cluster identifier from an Amazon DocumentDB endpoint.
+
+    Format: {cluster-id}.cluster-{hash}.{region}.docdb.amazonaws.com
+    Returns the first dot-delimited segment, or the full host if
+    the format doesn't match (e.g., localhost).
+    """
+    match = _CLUSTER_ID_PATTERN.match(host)
+    if match:
+        return match.group(1)
+    return host.split(".")[0] or host
+
+
+@dataclass
+class TelemetryConfig:
+    enabled: bool = False
+    """Main switch. When False, a NoOpBackend is used regardless of other settings."""
+
+    metrics_backend: MetricsBackend = MetricsBackend.LOG
+    """Where metric data points are published."""
+
+    traces_backend: TracesBackend = TracesBackend.LOG
+    """Where trace spans are published."""
+
+    cloudwatch_namespace: str | None = None
+    """CloudWatch namespace. If None (default), auto-derived as
+    'DocumentDB/{cluster-id}' from the host endpoint. Set explicitly
+    to override (e.g., 'DocumentDB/my-custom-name')."""
+
+    cloudwatch_flush_interval_seconds: float = 60
+    """How often buffered CloudWatch metrics are flushed."""
+
+    cloudwatch_client: Any = None
+    """Optional pre-configured boto3 CloudWatch client. If None, one is created."""
+
+    default_dimensions: dict[str, str] = field(default_factory=dict)
+    """Additional dimensions added to every metric beyond the auto-derived ones.
+    The 'service' dimension is automatically set from app_name if not provided here."""
+
+    log_level: int = 10  # logging.DEBUG
+    """Log level for the LOG backend."""
+
+    enabled_listeners: frozenset[str] = frozenset({"command", "heartbeat", "topology", "pool"})
+    """Which PyMongo monitoring listeners are active. Possible values:
+    'command', 'heartbeat', 'topology', 'pool'. Remove 'command' in
+    high-throughput environments to reduce overhead while keeping
+    infrastructure visibility (heartbeat, pool, topology)."""
+
+    emit_spans: bool = True
+    """Whether to emit span start/end events. When False, only metrics
+    are recorded — useful for production environments where per-operation
+    trace logging is too noisy but you still want counters and durations."""
+
+
+def build_backend(
+    config: TelemetryConfig,
+    host: str = "",
+    app_name: str | None = None,
+) -> TelemetryBackend:
+    """
+    Construct the appropriate backend from config.
+
+    Args:
+        config: TelemetryConfig instance
+        host: Cluster endpoint (used to auto-derive namespace and cluster dimension)
+        app_name: Service name (used as the 'service' dimension)
+    """
+    if not config.enabled:
+        return NoOpBackend()
+
+    # Build the effective dimensions: auto-derived + user-provided
+    dimensions = {}
+    if app_name:
+        dimensions["service"] = app_name
+    cluster_id = _extract_cluster_id(host) if host else None
+    if cluster_id:
+        dimensions["cluster"] = cluster_id
+    # User-provided dimensions override auto-derived ones
+    dimensions.update(config.default_dimensions)
+
+    if config.metrics_backend == MetricsBackend.CLOUDWATCH:
+        # Auto-derive namespace from cluster endpoint if not explicitly set
+        namespace = config.cloudwatch_namespace
+        if namespace is None:
+            namespace = f"DocumentDB/{cluster_id}" if cluster_id else "DocumentDB/Client"
+
+        from .cloudwatch_backend import CloudWatchBackend
+        return CloudWatchBackend(
+            namespace=namespace,
+            cloudwatch_client=config.cloudwatch_client,
+            flush_interval_seconds=config.cloudwatch_flush_interval_seconds,
+            default_dimensions=dimensions,
+        )
+
+    if config.metrics_backend == MetricsBackend.LOG or config.traces_backend == TracesBackend.LOG:
+        from .log_backend import LogBackend
+        return LogBackend(level=config.log_level)
+
+    return NoOpBackend()

--- a/developer/amazon-documentdb-python-client/src/docdb/telemetry/listeners.py
+++ b/developer/amazon-documentdb-python-client/src/docdb/telemetry/listeners.py
@@ -1,0 +1,223 @@
+"""
+PyMongo monitoring listeners that feed into the telemetry backend.
+
+PyMongo provides four listener types:
+- CommandListener: per-command start/success/failure
+- ServerHeartbeatListener: SDAM heartbeat events
+- TopologyListener: topology open/description-changed/closed
+- ConnectionPoolListener: pool events (created, checked out, closed)
+
+These listeners translate raw PyMongo events into the wrapper's
+metric/span model. Metrics use a flat, consistent dimension set
+designed for clean CloudWatch grouping:
+
+    Commands:  {command}
+    Pool:      {reason} (closed only) or no extra dimensions
+    Heartbeat: no extra dimensions (aggregate across nodes)
+    Topology:  no extra dimensions
+
+The default_dimensions from TelemetryConfig (service, environment, etc.)
+are appended automatically by the backend and listeners don't duplicate them.
+"""
+
+import threading
+import time
+
+from pymongo import monitoring
+
+from .backend import TelemetryBackend
+from .types import (
+    METRIC_COMMANDS_DURATION_MS,
+    METRIC_COMMANDS_FAILED,
+    METRIC_COMMANDS_TOTAL,
+    METRIC_CONNECTIONS_CLOSED,
+    METRIC_CONNECTIONS_OPENED,
+    METRIC_SERVER_HEARTBEAT_DURATION_MS,
+    METRIC_SERVER_HEARTBEAT_FAILED,
+    METRIC_TOPOLOGY_CHANGED,
+    MetricRecord,
+    MetricType,
+    SpanContext,
+)
+
+
+class DocumentDBCommandListener(monitoring.CommandListener):
+    """Tracks command execution: counts, durations, failures."""
+
+    def __init__(self, backend: TelemetryBackend, emit_spans: bool = True) -> None:
+        self._backend = backend
+        self._emit_spans = emit_spans
+        self._pending: dict[int, tuple[SpanContext | None, float]] = {}
+        self._pending_lock = threading.Lock()
+
+    def started(self, event: monitoring.CommandStartedEvent) -> None:
+        span = None
+        if self._emit_spans:
+            span = SpanContext(
+                name=f"docdb.command.{event.command_name}",
+                attributes={
+                    "db": event.database_name,
+                    "command": event.command_name,
+                    "server": f"{event.connection_id[0]}:{event.connection_id[1]}",
+                },
+            )
+            self._backend.start_span(span)
+        with self._pending_lock:
+            self._pending[event.request_id] = (span, time.perf_counter())
+        self._backend.record_metric(MetricRecord(
+            name=METRIC_COMMANDS_TOTAL,
+            value=1,
+            metric_type=MetricType.COUNTER,
+            unit="count",
+            dimensions={"command": event.command_name},
+        ))
+
+    def succeeded(self, event: monitoring.CommandSucceededEvent) -> None:
+        with self._pending_lock:
+            entry = self._pending.pop(event.request_id, None)
+        if entry:
+            span, start = entry
+            duration_ms = event.duration_micros / 1000.0
+            if self._emit_spans and span:
+                self._backend.end_span(span, duration_ms)
+            self._backend.record_metric(MetricRecord(
+                name=METRIC_COMMANDS_DURATION_MS,
+                value=duration_ms,
+                metric_type=MetricType.HISTOGRAM,
+                unit="ms",
+                dimensions={"command": event.command_name},
+            ))
+
+    def failed(self, event: monitoring.CommandFailedEvent) -> None:
+        with self._pending_lock:
+            entry = self._pending.pop(event.request_id, None)
+        duration_ms = event.duration_micros / 1000.0
+        if entry:
+            span, start = entry
+            if self._emit_spans and span:
+                self._backend.end_span(span, duration_ms, error=Exception(event.failure))
+        self._backend.record_metric(MetricRecord(
+            name=METRIC_COMMANDS_FAILED,
+            value=1,
+            metric_type=MetricType.COUNTER,
+            unit="count",
+            dimensions={"command": event.command_name},
+        ))
+        self._backend.record_metric(MetricRecord(
+            name=METRIC_COMMANDS_DURATION_MS,
+            value=duration_ms,
+            metric_type=MetricType.HISTOGRAM,
+            unit="ms",
+            dimensions={"command": event.command_name},
+        ))
+
+
+class DocumentDBHeartbeatListener(monitoring.ServerHeartbeatListener):
+    """Tracks heartbeat health."""
+
+    def __init__(self, backend: TelemetryBackend) -> None:
+        self._backend = backend
+
+    def started(self, event: monitoring.ServerHeartbeatStartedEvent) -> None:
+        pass
+
+    def succeeded(self, event: monitoring.ServerHeartbeatSucceededEvent) -> None:
+        self._backend.record_metric(MetricRecord(
+            name=METRIC_SERVER_HEARTBEAT_DURATION_MS,
+            value=event.duration * 1000.0,
+            metric_type=MetricType.HISTOGRAM,
+            unit="ms",
+        ))
+
+    def failed(self, event: monitoring.ServerHeartbeatFailedEvent) -> None:
+        self._backend.record_metric(MetricRecord(
+            name=METRIC_SERVER_HEARTBEAT_FAILED,
+            value=1,
+            metric_type=MetricType.COUNTER,
+            unit="count",
+        ))
+        self._backend.record_metric(MetricRecord(
+            name=METRIC_SERVER_HEARTBEAT_DURATION_MS,
+            value=event.duration * 1000.0,
+            metric_type=MetricType.HISTOGRAM,
+            unit="ms",
+        ))
+
+
+class DocumentDBTopologyListener(monitoring.TopologyListener):
+    """Tracks cluster topology changes."""
+
+    def __init__(self, backend: TelemetryBackend) -> None:
+        self._backend = backend
+
+    def opened(self, event: monitoring.TopologyOpenedEvent) -> None:
+        pass
+
+    def description_changed(self, event: monitoring.TopologyDescriptionChangedEvent) -> None:
+        prev_servers = set(event.previous_description.server_descriptions().keys())
+        new_servers = set(event.new_description.server_descriptions().keys())
+
+        added = new_servers - prev_servers
+        removed = prev_servers - new_servers
+
+        if added or removed:
+            self._backend.record_metric(MetricRecord(
+                name=METRIC_TOPOLOGY_CHANGED,
+                value=len(added) + len(removed),
+                metric_type=MetricType.COUNTER,
+                unit="count",
+            ))
+
+    def closed(self, event: monitoring.TopologyClosedEvent) -> None:
+        pass
+
+
+class DocumentDBPoolListener(monitoring.ConnectionPoolListener):
+    """Tracks connection pool activity."""
+
+    def __init__(self, backend: TelemetryBackend) -> None:
+        self._backend = backend
+
+    def pool_created(self, event: monitoring.PoolCreatedEvent) -> None:
+        pass
+
+    def pool_ready(self, event: monitoring.PoolReadyEvent) -> None:
+        pass
+
+    def pool_cleared(self, event: monitoring.PoolClearedEvent) -> None:
+        pass
+
+    def pool_closed(self, event: monitoring.PoolClosedEvent) -> None:
+        pass
+
+    def connection_created(self, event: monitoring.ConnectionCreatedEvent) -> None:
+        self._backend.record_metric(MetricRecord(
+            name=METRIC_CONNECTIONS_OPENED,
+            value=1,
+            metric_type=MetricType.COUNTER,
+            unit="count",
+        ))
+
+    def connection_ready(self, event: monitoring.ConnectionReadyEvent) -> None:
+        pass
+
+    def connection_closed(self, event: monitoring.ConnectionClosedEvent) -> None:
+        self._backend.record_metric(MetricRecord(
+            name=METRIC_CONNECTIONS_CLOSED,
+            value=1,
+            metric_type=MetricType.COUNTER,
+            unit="count",
+            dimensions={"reason": event.reason},
+        ))
+
+    def connection_check_out_started(self, event: monitoring.ConnectionCheckOutStartedEvent) -> None:
+        pass
+
+    def connection_check_out_failed(self, event: monitoring.ConnectionCheckOutFailedEvent) -> None:
+        pass
+
+    def connection_checked_out(self, event: monitoring.ConnectionCheckedOutEvent) -> None:
+        pass
+
+    def connection_checked_in(self, event: monitoring.ConnectionCheckedInEvent) -> None:
+        pass

--- a/developer/amazon-documentdb-python-client/src/docdb/telemetry/log_backend.py
+++ b/developer/amazon-documentdb-python-client/src/docdb/telemetry/log_backend.py
@@ -1,0 +1,75 @@
+"""
+Logging-based telemetry backend.
+
+Emits metrics and spans as structured log records. Suitable for
+development, debugging, and environments where log aggregation
+(CloudWatch Logs, Datadog, Splunk) provides observability.
+"""
+
+import logging
+
+from .backend import TelemetryBackend
+from .types import MetricRecord, MetricType, SpanContext
+
+logger = logging.getLogger("docdb.telemetry")
+
+
+class LogBackend(TelemetryBackend):
+    """Emits all telemetry as structured log messages."""
+
+    def __init__(self, level: int = logging.DEBUG) -> None:
+        self._level = level
+
+    def record_metric(self, metric: MetricRecord) -> None:
+        extra = {
+            "metric_name": metric.name,
+            "metric_type": metric.metric_type.value,
+            "value": metric.value,
+        }
+        if metric.unit:
+            extra["unit"] = metric.unit
+        if metric.dimensions:
+            extra["dimensions"] = metric.dimensions
+
+        if metric.metric_type == MetricType.COUNTER:
+            logger.log(self._level, "[metric] %s += %s", metric.name, metric.value, extra=extra)
+        elif metric.metric_type == MetricType.GAUGE:
+            logger.log(self._level, "[metric] %s = %s", metric.name, metric.value, extra=extra)
+        else:
+            logger.log(self._level, "[metric] %s: %s", metric.name, metric.value, extra=extra)
+
+    def start_span(self, span: SpanContext) -> None:
+        logger.log(
+            self._level,
+            "[span:start] %s",
+            span.name,
+            extra={"span_name": span.name, "attributes": span.attributes},
+        )
+
+    def end_span(self, span: SpanContext, duration_ms: float, error: Exception | None = None) -> None:
+        extra = {"span_name": span.name, "duration_ms": duration_ms}
+        if error:
+            extra["error"] = str(error)
+            logger.log(
+                self._level,
+                "[span:end] %s duration=%.1fms error=%s",
+                span.name,
+                duration_ms,
+                type(error).__name__,
+                extra=extra,
+            )
+        else:
+            logger.log(
+                self._level,
+                "[span:end] %s duration=%.1fms",
+                span.name,
+                duration_ms,
+                extra=extra,
+            )
+
+    def flush(self) -> None:
+        for handler in logger.handlers:
+            handler.flush()
+
+    def shutdown(self) -> None:
+        pass

--- a/developer/amazon-documentdb-python-client/src/docdb/telemetry/types.py
+++ b/developer/amazon-documentdb-python-client/src/docdb/telemetry/types.py
@@ -1,0 +1,64 @@
+"""
+Telemetry types: enums, metric descriptors, and span context.
+
+- Named counters and gauges emitted by internal components
+- Trace spans wrapping operations for distributed tracing visibility
+- Pluggable backends (NONE, LOG, CLOUDWATCH, OTLP)
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class MetricsBackend(Enum):
+    NONE = "none"
+    LOG = "log"
+    CLOUDWATCH = "cloudwatch"
+
+
+class TracesBackend(Enum):
+    NONE = "none"
+    LOG = "log"
+
+
+class MetricType(Enum):
+    COUNTER = "counter"
+    GAUGE = "gauge"
+    HISTOGRAM = "histogram"
+
+
+@dataclass
+class MetricRecord:
+    name: str
+    value: float
+    metric_type: MetricType
+    unit: str = ""
+    dimensions: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class SpanContext:
+    name: str
+    attributes: dict[str, Any] = field(default_factory=dict)
+    parent: "SpanContext | None" = None
+
+
+# Pre-defined metric names
+#
+# CloudWatch dimension layout:
+#   Commands:   default_dimensions + {command}
+#   Pool:       default_dimensions + {reason} (closed only) or default_dimensions only
+#   Heartbeat:  default_dimensions only (aggregated across nodes)
+#   Topology:   default_dimensions only
+METRIC_COMMANDS_TOTAL = "docdb.commands.total"
+METRIC_COMMANDS_FAILED = "docdb.commands.failed"
+METRIC_COMMANDS_DURATION_MS = "docdb.commands.duration_ms"
+METRIC_CONNECTIONS_OPENED = "docdb.connections.opened"
+METRIC_CONNECTIONS_CLOSED = "docdb.connections.closed"
+METRIC_SERVER_HEARTBEAT_DURATION_MS = "docdb.heartbeat.duration_ms"
+METRIC_SERVER_HEARTBEAT_FAILED = "docdb.heartbeat.failed"
+METRIC_TOPOLOGY_CHANGED = "docdb.topology.changed"
+METRIC_TRACKER_POOL_RESET = "docdb.tracker.pool_reset"
+METRIC_RETRY_TRIGGERED = "docdb.retry.triggered"
+METRIC_RETRY_EXHAUSTED = "docdb.retry.exhausted"


### PR DESCRIPTION
Adds a Python wrapper library for PyMongo that enforces Amazon DocumentDB best practices automatically. This is the first contribution to a new `developer/` directory for libraries and SDKs that help developers build applications on DocumentDB.

The library has two layers:

1. Safe defaults - enforced at MongoClient construction (TLS, replica set, pool sizing, timeouts)
2. Plugin chain - composable middleware for retry, telemetry, and custom logic without modifying application code

...and provides the following:
|   | Description |
| --- | --- |
| Connection management | singleton client with pre-warmed pool (`min_pool_size=5`) |
| Replica-set routing | enforces `replicaSet=rs0` and `directConnection=False` |
| Read distribution | defaults to `secondaryPreferred` |
| Retry with backoff | plugin-based exponential retry with jitter (reads by default, opt-in for idempotent writes) |
| Telemetry | per-service, per-command CloudWatch metrics |
| Connection tracking | proactively closes stale connections on topology changes |

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.